### PR TITLE
feat: report runtime info

### DIFF
--- a/codegen/internal/generator/templates/api_version.tmpl
+++ b/codegen/internal/generator/templates/api_version.tmpl
@@ -1,0 +1,6 @@
+namespace {{ .Namespace }};
+
+internal static class ApiVersionInfo
+{
+    internal const string Value = "{{ .ApiVersion }}";
+}

--- a/src/SumUp.Tests/RuntimeHeadersTests.cs
+++ b/src/SumUp.Tests/RuntimeHeadersTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using SumUp.Http;
+using Xunit;
+
+namespace SumUp.Tests;
+
+public class RuntimeHeadersTests
+{
+    [Fact]
+    public void CreateRequest_AddsRuntimeHeaders()
+    {
+        using var httpClient = new HttpClient { BaseAddress = new Uri("https://api.sumup.com") };
+        var options = new SumUpClientOptions();
+        var apiClient = new ApiClient(httpClient, options);
+
+        var request = apiClient.CreateRequest(HttpMethod.Get, "/ping");
+
+        AssertHeader(request, "X-Sumup-Api-Version", ApiVersionInfo.Value);
+        AssertHeader(request, "X-Sumup-Lang", "dotnet");
+        AssertHeader(request, "X-Sumup-Runtime", "dotnet");
+        AssertHeader(request, "X-Sumup-Os", GetExpectedOs());
+        AssertHeader(request, "X-Sumup-Arch", GetExpectedArch());
+
+        Assert.True(request.Headers.Contains("X-Sumup-Package-Version"));
+        Assert.True(request.Headers.Contains("X-Sumup-Runtime-Version"));
+    }
+
+    private static void AssertHeader(HttpRequestMessage request, string name, string expected)
+    {
+        Assert.True(request.Headers.TryGetValues(name, out var values));
+        Assert.Contains(expected, values);
+    }
+
+    private static string GetExpectedOs()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "windows";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return "linux";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "darwin";
+        }
+
+        return RuntimeInformation.OSDescription;
+    }
+
+    private static string GetExpectedArch()
+    {
+        return RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64 => "x86_64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            Architecture.Arm => "arm",
+            _ => RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/src/SumUp/Http/ApiClient.cs
+++ b/src/SumUp/Http/ApiClient.cs
@@ -36,6 +36,7 @@ internal sealed class ApiClient
         request.Headers.Accept.Clear();
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Headers.UserAgent.ParseAdd(_options.UserAgent);
+        RuntimeHeaders.Apply(request.Headers);
 
         return request;
     }

--- a/src/SumUp/Http/ApiVersion.g.cs
+++ b/src/SumUp/Http/ApiVersion.g.cs
@@ -1,0 +1,6 @@
+namespace SumUp;
+
+internal static class ApiVersionInfo
+{
+    internal const string Value = "1.0.0";
+}

--- a/src/SumUp/Http/RuntimeHeaders.cs
+++ b/src/SumUp/Http/RuntimeHeaders.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace SumUp.Http;
+
+internal static class RuntimeHeaders
+{
+    private const string Language = "dotnet";
+    private const string Runtime = "dotnet";
+
+    private static readonly string PackageVersion =
+        Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0";
+
+    private static readonly string OsName = GetOsName();
+    private static readonly string RuntimeArch = GetArchitecture();
+    private static readonly string RuntimeVersion = RuntimeInformation.FrameworkDescription;
+
+    internal static void Apply(HttpRequestHeaders headers)
+    {
+        SetHeader(headers, "X-Sumup-Api-Version", ApiVersionInfo.Value);
+        SetHeader(headers, "X-Sumup-Lang", Language);
+        SetHeader(headers, "X-Sumup-Package-Version", PackageVersion);
+        SetHeader(headers, "X-Sumup-Os", OsName);
+        SetHeader(headers, "X-Sumup-Arch", RuntimeArch);
+        SetHeader(headers, "X-Sumup-Runtime", Runtime);
+        SetHeader(headers, "X-Sumup-Runtime-Version", RuntimeVersion);
+    }
+
+    private static void SetHeader(HttpRequestHeaders headers, string name, string value)
+    {
+        headers.Remove(name);
+        headers.TryAddWithoutValidation(name, value);
+    }
+
+    private static string GetOsName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "windows";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return "linux";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "darwin";
+        }
+
+        return RuntimeInformation.OSDescription;
+    }
+
+    private static string GetArchitecture()
+    {
+        return RuntimeInformation.OSArchitecture switch
+        {
+            System.Runtime.InteropServices.Architecture.X64 => "x86_64",
+            System.Runtime.InteropServices.Architecture.X86 => "x86",
+            System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
+            System.Runtime.InteropServices.Architecture.Arm => "arm",
+            _ => RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant()
+        };
+    }
+}


### PR DESCRIPTION
Propagate more information about the SDK's runtime including the API version, package version, etc. to get more observability into the SDKs usage.

Also removes the generation of the client/client.go file as it doesn't depend on the OpenAPI specs and can be maintained manually.
