### PR TITLE
fix(codegen): deserialize typed JSON responses instead of casting JsonDocument

### DIFF
--- a/src/SumUp/CheckoutsClient.g.cs
+++ b/src/SumUp/CheckoutsClient.g.cs
@@ -522,9 +522,9 @@ public sealed partial class CheckoutsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
-            var document = JsonDocument.Parse(jsonStream);
-            return ApiResponse<CheckoutsListAvailablePaymentMethodsResponse>.From((CheckoutsListAvailablePaymentMethodsResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
+            var result = JsonSerializer.Deserialize<CheckoutsListAvailablePaymentMethodsResponse>(stream, _client.SerializerOptions);
+            return ApiResponse<CheckoutsListAvailablePaymentMethodsResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -580,9 +580,9 @@ public sealed partial class CheckoutsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
-            var document = await JsonDocument.ParseAsync(jsonStream, cancellationToken: effectiveCancellationToken).ConfigureAwait(false);
-            return ApiResponse<CheckoutsListAvailablePaymentMethodsResponse>.From((CheckoutsListAvailablePaymentMethodsResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<CheckoutsListAvailablePaymentMethodsResponse>(stream, _client.SerializerOptions, effectiveCancellationToken).ConfigureAwait(false);
+            return ApiResponse<CheckoutsListAvailablePaymentMethodsResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {

--- a/src/SumUp/MembersClient.g.cs
+++ b/src/SumUp/MembersClient.g.cs
@@ -401,9 +401,9 @@ public sealed partial class MembersClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
-            var document = JsonDocument.Parse(jsonStream);
-            return ApiResponse<MembersListResponse>.From((MembersListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
+            var result = JsonSerializer.Deserialize<MembersListResponse>(stream, _client.SerializerOptions);
+            return ApiResponse<MembersListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -464,9 +464,9 @@ public sealed partial class MembersClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
-            var document = await JsonDocument.ParseAsync(jsonStream, cancellationToken: effectiveCancellationToken).ConfigureAwait(false);
-            return ApiResponse<MembersListResponse>.From((MembersListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<MembersListResponse>(stream, _client.SerializerOptions, effectiveCancellationToken).ConfigureAwait(false);
+            return ApiResponse<MembersListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {

--- a/src/SumUp/MembershipsClient.g.cs
+++ b/src/SumUp/MembershipsClient.g.cs
@@ -69,9 +69,9 @@ public sealed partial class MembershipsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
-            var document = JsonDocument.Parse(jsonStream);
-            return ApiResponse<MembershipsListResponse>.From((MembershipsListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
+            var result = JsonSerializer.Deserialize<MembershipsListResponse>(stream, _client.SerializerOptions);
+            return ApiResponse<MembershipsListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -128,9 +128,9 @@ public sealed partial class MembershipsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
-            var document = await JsonDocument.ParseAsync(jsonStream, cancellationToken: effectiveCancellationToken).ConfigureAwait(false);
-            return ApiResponse<MembershipsListResponse>.From((MembershipsListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<MembershipsListResponse>(stream, _client.SerializerOptions, effectiveCancellationToken).ConfigureAwait(false);
+            return ApiResponse<MembershipsListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {

--- a/src/SumUp/ReadersClient.g.cs
+++ b/src/SumUp/ReadersClient.g.cs
@@ -708,9 +708,9 @@ public sealed partial class ReadersClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
-            var document = JsonDocument.Parse(jsonStream);
-            return ApiResponse<ReadersListResponse>.From((ReadersListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
+            var result = JsonSerializer.Deserialize<ReadersListResponse>(stream, _client.SerializerOptions);
+            return ApiResponse<ReadersListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -749,9 +749,9 @@ public sealed partial class ReadersClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
-            var document = await JsonDocument.ParseAsync(jsonStream, cancellationToken: effectiveCancellationToken).ConfigureAwait(false);
-            return ApiResponse<ReadersListResponse>.From((ReadersListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<ReadersListResponse>(stream, _client.SerializerOptions, effectiveCancellationToken).ConfigureAwait(false);
+            return ApiResponse<ReadersListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {

--- a/src/SumUp/RolesClient.g.cs
+++ b/src/SumUp/RolesClient.g.cs
@@ -386,9 +386,9 @@ public sealed partial class RolesClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
-            var document = JsonDocument.Parse(jsonStream);
-            return ApiResponse<RolesListResponse>.From((RolesListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
+            var result = JsonSerializer.Deserialize<RolesListResponse>(stream, _client.SerializerOptions);
+            return ApiResponse<RolesListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -435,9 +435,9 @@ public sealed partial class RolesClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
-            var document = await JsonDocument.ParseAsync(jsonStream, cancellationToken: effectiveCancellationToken).ConfigureAwait(false);
-            return ApiResponse<RolesListResponse>.From((RolesListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<RolesListResponse>(stream, _client.SerializerOptions, effectiveCancellationToken).ConfigureAwait(false);
+            return ApiResponse<RolesListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {

--- a/src/SumUp/TransactionsClient.g.cs
+++ b/src/SumUp/TransactionsClient.g.cs
@@ -329,9 +329,9 @@ public sealed partial class TransactionsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
-            var document = JsonDocument.Parse(jsonStream);
-            return ApiResponse<TransactionsListResponse>.From((TransactionsListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
+            var result = JsonSerializer.Deserialize<TransactionsListResponse>(stream, _client.SerializerOptions);
+            return ApiResponse<TransactionsListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -404,9 +404,9 @@ public sealed partial class TransactionsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
-            var document = await JsonDocument.ParseAsync(jsonStream, cancellationToken: effectiveCancellationToken).ConfigureAwait(false);
-            return ApiResponse<TransactionsListResponse>.From((TransactionsListResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<TransactionsListResponse>(stream, _client.SerializerOptions, effectiveCancellationToken).ConfigureAwait(false);
+            return ApiResponse<TransactionsListResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -475,9 +475,9 @@ public sealed partial class TransactionsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
-            var document = JsonDocument.Parse(jsonStream);
-            return ApiResponse<TransactionsListDeprecatedResponse>.From((TransactionsListDeprecatedResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).GetAwaiter().GetResult();
+            var result = JsonSerializer.Deserialize<TransactionsListDeprecatedResponse>(stream, _client.SerializerOptions);
+            return ApiResponse<TransactionsListDeprecatedResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {
@@ -546,9 +546,9 @@ public sealed partial class TransactionsClient
                 var fallbackError = _client.TryDeserialize<ApiError>(responseBody);
                 throw new ApiException(response.StatusCode, fallbackError, responseBody, response.RequestMessage?.RequestUri);
             }
-            using var jsonStream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
-            var document = await JsonDocument.ParseAsync(jsonStream, cancellationToken: effectiveCancellationToken).ConfigureAwait(false);
-            return ApiResponse<TransactionsListDeprecatedResponse>.From((TransactionsListDeprecatedResponse)(object)document, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
+            using var stream = await ApiClient.ReadContentAsStreamAsync(response.Content!, effectiveCancellationToken).ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<TransactionsListDeprecatedResponse>(stream, _client.SerializerOptions, effectiveCancellationToken).ConfigureAwait(false);
+            return ApiResponse<TransactionsListDeprecatedResponse>.From(result, response.StatusCode, response.Headers, response.RequestMessage?.RequestUri);
         }
         finally
         {


### PR DESCRIPTION
Issue #30 reported `InvalidCastException` in `ReadersClient.List/ListAsync`. The generated SDK code parsed response content as `JsonDocument` and cast it to `ReadersListResponse`, which fails at runtime.

Root cause:
- response mode selection re-inferred type from raw response schema
- for some inline/object responses it chose "json-document"
- generated clients emitted `(T)(object)document` casts for typed responses

Fix:
- change response mode resolution to use the already resolved response type from resolveResponseType(...)
- keep "json-document" mode only when `ResponseType` is `JsonDocument`
- use normal JSON deserialization for typed responses

Added regression test.

Fixes: https://github.com/sumup/sumup-dotnet/issues/30
