### PR TITLE
feat(query): support explicit null query parameters

### DIFF
--- a/src/SumUp.Tests/RequestBuilderTests.cs
+++ b/src/SumUp.Tests/RequestBuilderTests.cs
@@ -27,4 +27,24 @@ public class RequestBuilderTests
 
         Assert.Equal("https://api.sumup.com/v0.1/items?status=open&status=closed", request.RequestUri!.AbsoluteUri);
     }
+
+    [Fact]
+    public void Build_OmitsUnsetOptionalQuery()
+    {
+        var builder = new RequestBuilder(HttpMethod.Get, "/v0.1/items", new Uri("https://api.sumup.com"));
+        builder.AddQuery("status", OptionalQuery<string>.Unset);
+        var request = builder.Build();
+
+        Assert.Equal("https://api.sumup.com/v0.1/items", request.RequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
+    public void Build_EmitsExplicitNullOptionalQuery()
+    {
+        var builder = new RequestBuilder(HttpMethod.Get, "/v0.1/items", new Uri("https://api.sumup.com"));
+        builder.AddQuery("status", OptionalQuery<string>.Null());
+        var request = builder.Build();
+
+        Assert.Equal("https://api.sumup.com/v0.1/items?status=null", request.RequestUri!.AbsoluteUri);
+    }
 }

--- a/src/SumUp/Http/RequestBuilder.cs
+++ b/src/SumUp/Http/RequestBuilder.cs
@@ -64,6 +64,22 @@ internal sealed class RequestBuilder
         _query.Add(new KeyValuePair<string, string>(name, ConvertToString(value)));
     }
 
+    internal void AddQuery<T>(string name, OptionalQuery<T> value)
+    {
+        if (!value.IsSet)
+        {
+            return;
+        }
+
+        if (value.IsNull)
+        {
+            _query.Add(new KeyValuePair<string, string>(name, "null"));
+            return;
+        }
+
+        AddQuery(name, value.RawValue);
+    }
+
     internal void AddHeader(string name, object? value)
     {
         if (value is null)

--- a/src/SumUp/MembershipsClient.g.cs
+++ b/src/SumUp/MembershipsClient.g.cs
@@ -36,7 +36,7 @@ public sealed partial class MembershipsClient
     /// <param name="roles">Filter the returned memberships by role.</param>
     /// <param name="requestOptions">Optional per-request overrides.</param>
     /// <param name="cancellationToken">Token used to cancel the request.</param>
-    public ApiResponse<MembershipsListResponse> List(int? offset = null, int? limit = null, string? kind = null, MembershipStatus? status = null, string? resourceType = null, bool? resourceAttributesSandbox = null, string? resourceName = null, string? resourceParentId = null, string? resourceParentType = null, IEnumerable<string>? roles = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+    public ApiResponse<MembershipsListResponse> List(int? offset = null, int? limit = null, string? kind = null, MembershipStatus? status = null, string? resourceType = null, bool? resourceAttributesSandbox = null, string? resourceName = null, OptionalQuery<string> resourceParentId = default, OptionalQuery<string> resourceParentType = default, IEnumerable<string>? roles = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
     {
         var request = _client.CreateRequest(HttpMethod.Get, "/v0.1/memberships", builder =>
         {
@@ -95,7 +95,7 @@ public sealed partial class MembershipsClient
     /// <param name="roles">Filter the returned memberships by role.</param>
     /// <param name="requestOptions">Optional per-request overrides.</param>
     /// <param name="cancellationToken">Token used to cancel the request.</param>
-    public async Task<ApiResponse<MembershipsListResponse>> ListAsync(int? offset = null, int? limit = null, string? kind = null, MembershipStatus? status = null, string? resourceType = null, bool? resourceAttributesSandbox = null, string? resourceName = null, string? resourceParentId = null, string? resourceParentType = null, IEnumerable<string>? roles = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+    public async Task<ApiResponse<MembershipsListResponse>> ListAsync(int? offset = null, int? limit = null, string? kind = null, MembershipStatus? status = null, string? resourceType = null, bool? resourceAttributesSandbox = null, string? resourceName = null, OptionalQuery<string> resourceParentId = default, OptionalQuery<string> resourceParentType = default, IEnumerable<string>? roles = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
     {
         var request = _client.CreateRequest(HttpMethod.Get, "/v0.1/memberships", builder =>
         {

--- a/src/SumUp/OptionalQuery.cs
+++ b/src/SumUp/OptionalQuery.cs
@@ -1,0 +1,42 @@
+namespace SumUp;
+
+/// <summary>
+/// Represents a query parameter that can be omitted, set to a value, or set explicitly to null.
+/// </summary>
+public readonly struct OptionalQuery<T>
+{
+    internal object? RawValue { get; }
+
+    /// <summary>
+    /// Indicates whether the query parameter should be emitted.
+    /// </summary>
+    public bool IsSet { get; }
+
+    /// <summary>
+    /// Indicates whether the query parameter should be emitted with a literal null value.
+    /// </summary>
+    public bool IsNull => IsSet && RawValue is null;
+
+    private OptionalQuery(bool isSet, object? value)
+    {
+        IsSet = isSet;
+        RawValue = value;
+    }
+
+    /// <summary>
+    /// Omits the parameter from the query string.
+    /// </summary>
+    public static OptionalQuery<T> Unset => default;
+
+    /// <summary>
+    /// Emits the parameter as an explicit null literal.
+    /// </summary>
+    public static OptionalQuery<T> Null() => new(isSet: true, value: null);
+
+    /// <summary>
+    /// Emits the parameter with the provided value.
+    /// </summary>
+    public static OptionalQuery<T> From(T value) => new(isSet: true, value: value);
+
+    public static implicit operator OptionalQuery<T>(T value) => From(value);
+}


### PR DESCRIPTION
Introduce `OptionalQuery<T>` tri-state query value (unset/value/null) and add `RequestBuilder` support to emit literal nulls when requested.

Update codegen to generate `OptionalQuery<...>` for nullable optional query parameters so callers can omit a parameter or send explicit null semantics as required by API filters.

Add `RequestBuilder` tests for unset and explicit null behavior.