### PR TITLE
fix(client): send problem+json accept header

### DIFF
--- a/src/SumUp.Tests/ReadersClientTests.cs
+++ b/src/SumUp.Tests/ReadersClientTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -126,7 +127,8 @@ public class ReadersClientTests
         var request = handler.LastRequest!;
         Assert.Equal(HttpMethod.Get, request.Method);
         Assert.Equal("/v0.1/merchants/merchant-123/readers/reader-456/status", request.RequestUri!.AbsolutePath);
-        Assert.Equal("application/json", Assert.Single(request.Headers.Accept).MediaType);
+        var acceptHeaders = request.Headers.Accept.Select(value => value.MediaType).ToArray();
+        Assert.Equal(new[] { "application/problem+json", "application/json" }, acceptHeaders);
         Assert.Null(request.Content);
         Assert.True(request.Headers.TryGetValues("Authorization", out var authorizationHeaders));
         Assert.Contains("Bearer test-token", authorizationHeaders);

--- a/src/SumUp/Http/ApiClient.cs
+++ b/src/SumUp/Http/ApiClient.cs
@@ -38,6 +38,7 @@ internal sealed class ApiClient
         var request = builder.Build();
 
         request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/problem+json"));
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Headers.UserAgent.ParseAdd(_options.UserAgent);
         RuntimeHeaders.Apply(request.Headers);


### PR DESCRIPTION
## Summary
- send `Accept: application/problem+json, application/json` by default on SDK requests
- update related tests/templates where needed

## Verification
- Ran available targeted tests locally for this repository when possible.