### PR TITLE
fix(codegen): prefer problem+json for response schemas

### DIFF
--- a/codegen/internal/generator/generator.go
+++ b/codegen/internal/generator/generator.go
@@ -1295,13 +1295,11 @@ func preferredSchema(content *orderedmap.Map[string, *v3.MediaType]) *base.Schem
 	if content == nil {
 		return nil
 	}
-	if media := content.GetOrZero("application/json"); media != nil && media.Schema != nil {
+	if media := content.GetOrZero("application/problem+json"); media != nil && media.Schema != nil {
 		return media.Schema
 	}
-	for _, media := range content.FromOldest() {
-		if media != nil && media.Schema != nil {
-			return media.Schema
-		}
+	if media := content.GetOrZero("application/json"); media != nil && media.Schema != nil {
+		return media.Schema
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- prefer `application/problem+json` for response schema generation when present
- fall back to `application/json`
- do not generate support for multiple response media types at once

## Notes
- This branch is based on the latest `main` and includes only the second-pass response media-type selection update.