### PR TITLE
fix: enum serialization

### DIFF
--- a/codegen/internal/generator/templates/model_enum.tmpl
+++ b/codegen/internal/generator/templates/model_enum.tmpl
@@ -7,7 +7,7 @@ namespace {{ .Namespace }};
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum {{ .Name }}
 {
 {{- range .EnumValues }}

--- a/src/SumUp.Tests/RequestBuilderTests.cs
+++ b/src/SumUp.Tests/RequestBuilderTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Net.Http;
+using System.Text;
 using SumUp.Http;
 using Xunit;
 
@@ -46,5 +48,27 @@ public class RequestBuilderTests
         var request = builder.Build();
 
         Assert.Equal("https://api.sumup.com/v0.1/items?status=null", request.RequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
+    public void CreateContent_SerializesEnumMemberValues()
+    {
+        using var httpClient = new HttpClient { BaseAddress = new Uri("https://api.sumup.com") };
+        var apiClient = new ApiClient(httpClient, new SumUpClientOptions());
+        var request = new CheckoutCreateRequest
+        {
+            CheckoutReference = "test-123",
+            Amount = 10.0f,
+            Currency = Currency.Eur,
+            MerchantCode = "merchant-code",
+            Description = "Test order",
+        };
+
+        using var content = apiClient.CreateContent(request, "application/json");
+        using var stream = content.ReadAsStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var body = reader.ReadToEnd();
+
+        Assert.Contains("\"currency\":\"EUR\"", body);
     }
 }

--- a/src/SumUp.Tests/SumUpClientOptionsTests.cs
+++ b/src/SumUp.Tests/SumUpClientOptionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -50,5 +51,13 @@ public class SumUpClientOptionsTests
         {
             Environment.SetEnvironmentVariable(variable, originalValue);
         }
+    }
+
+    [Fact]
+    public void JsonSerializer_UsesEnumMemberValueForStandaloneEnums()
+    {
+        var json = JsonSerializer.Serialize(Currency.Eur);
+
+        Assert.Equal("\"EUR\"", json);
     }
 }

--- a/src/SumUp/EnumMemberJsonConverterFactory.cs
+++ b/src/SumUp/EnumMemberJsonConverterFactory.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SumUp;
+
+/// <summary>
+/// Serializes enums using <see cref="EnumMemberAttribute.Value"/> when present.
+/// Replace this with built-in enum member name support once the SDK can target a newer .NET runtime across all TFMs.
+/// </summary>
+public sealed class EnumMemberJsonConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert)
+    {
+        var enumType = Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert;
+        return enumType.IsEnum;
+    }
+
+    /// <inheritdoc />
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(typeToConvert);
+        var enumType = underlyingType ?? typeToConvert;
+        var converterType = underlyingType is null
+            ? typeof(EnumMemberJsonConverter<>).MakeGenericType(enumType)
+            : typeof(NullableEnumMemberJsonConverter<>).MakeGenericType(enumType);
+
+        return (JsonConverter)Activator.CreateInstance(converterType)!;
+    }
+
+    private sealed class NullableEnumMemberJsonConverter<TEnum> : JsonConverter<TEnum?>
+        where TEnum : struct, Enum
+    {
+        private static readonly EnumMemberJsonConverter<TEnum> InnerConverter = new();
+
+        public override TEnum? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            return InnerConverter.Read(ref reader, typeof(TEnum), options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, TEnum? value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            InnerConverter.Write(writer, value.Value, options);
+        }
+    }
+
+    private sealed class EnumMemberJsonConverter<TEnum> : JsonConverter<TEnum>
+        where TEnum : struct, Enum
+    {
+        private static readonly IReadOnlyDictionary<TEnum, string> WriteMappings = BuildWriteMappings();
+        private static readonly IReadOnlyDictionary<string, TEnum> ReadMappings = BuildReadMappings(WriteMappings);
+
+        public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var value = reader.GetString();
+                if (value is not null)
+                {
+                    if (ReadMappings.TryGetValue(value, out var mapped))
+                    {
+                        return mapped;
+                    }
+
+                    if (Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed))
+                    {
+                        return parsed;
+                    }
+                }
+            }
+            else if (reader.TokenType == JsonTokenType.Number)
+            {
+                return ReadNumeric(ref reader);
+            }
+
+            throw new JsonException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Unable to convert value to enum type '{0}'.",
+                    typeof(TEnum).FullName));
+        }
+
+        public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+        {
+            if (WriteMappings.TryGetValue(value, out var mapped))
+            {
+                writer.WriteStringValue(mapped);
+                return;
+            }
+
+            var name = Enum.GetName(typeof(TEnum), value);
+            if (name is not null)
+            {
+                writer.WriteStringValue(name);
+                return;
+            }
+
+            WriteNumeric(writer, value);
+        }
+
+        private static Dictionary<TEnum, string> BuildWriteMappings()
+        {
+            var values = new Dictionary<TEnum, string>();
+            foreach (var field in typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static))
+            {
+                var enumValue = (TEnum)field.GetValue(null)!;
+                var enumMember = field.GetCustomAttribute<EnumMemberAttribute>();
+                values[enumValue] = enumMember?.Value ?? field.Name;
+            }
+
+            return values;
+        }
+
+        private static Dictionary<string, TEnum> BuildReadMappings(IReadOnlyDictionary<TEnum, string> writeMappings)
+        {
+            var values = new Dictionary<string, TEnum>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pair in writeMappings)
+            {
+                values[pair.Value] = pair.Key;
+                values[pair.Key.ToString()] = pair.Key;
+            }
+
+            foreach (var value in Enum.GetValues(typeof(TEnum)).Cast<TEnum>())
+            {
+                values[value.ToString()] = value;
+            }
+
+            return values;
+        }
+
+        private static TEnum ReadNumeric(ref Utf8JsonReader reader)
+        {
+            object value = Type.GetTypeCode(Enum.GetUnderlyingType(typeof(TEnum))) switch
+            {
+                TypeCode.SByte => reader.GetSByte(),
+                TypeCode.Byte => reader.GetByte(),
+                TypeCode.Int16 => reader.GetInt16(),
+                TypeCode.UInt16 => reader.GetUInt16(),
+                TypeCode.Int32 => reader.GetInt32(),
+                TypeCode.UInt32 => reader.GetUInt32(),
+                TypeCode.Int64 => reader.GetInt64(),
+                TypeCode.UInt64 => reader.GetUInt64(),
+                _ => throw new JsonException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Enum type '{0}' has an unsupported underlying type.",
+                        typeof(TEnum).FullName)),
+            };
+
+            return (TEnum)Enum.ToObject(typeof(TEnum), value);
+        }
+
+        private static void WriteNumeric(Utf8JsonWriter writer, TEnum value)
+        {
+            switch (Type.GetTypeCode(Enum.GetUnderlyingType(typeof(TEnum))))
+            {
+                case TypeCode.SByte:
+                    writer.WriteNumberValue(Convert.ToSByte(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.Byte:
+                    writer.WriteNumberValue(Convert.ToByte(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.Int16:
+                    writer.WriteNumberValue(Convert.ToInt16(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.UInt16:
+                    writer.WriteNumberValue(Convert.ToUInt16(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.Int32:
+                    writer.WriteNumberValue(Convert.ToInt32(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.UInt32:
+                    writer.WriteNumberValue(Convert.ToUInt32(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.Int64:
+                    writer.WriteNumberValue(Convert.ToInt64(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.UInt64:
+                    writer.WriteNumberValue(Convert.ToUInt64(value, CultureInfo.InvariantCulture));
+                    return;
+                default:
+                    throw new JsonException(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "Enum type '{0}' has an unsupported underlying type.",
+                            typeof(TEnum).FullName));
+            }
+        }
+    }
+}

--- a/src/SumUp/Http/ApiClient.cs
+++ b/src/SumUp/Http/ApiClient.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,7 +27,7 @@ internal sealed class ApiClient
         {
             PropertyNameCaseInsensitive = true
         };
-        _serializerOptions.Converters.Add(new JsonStringEnumConverter());
+        _serializerOptions.Converters.Add(new EnumMemberJsonConverterFactory());
     }
 
     internal HttpRequestMessage CreateRequest(HttpMethod method, string pathTemplate, Action<RequestBuilder>? configure = null)

--- a/src/SumUp/Models/CardType.g.cs
+++ b/src/SumUp/Models/CardType.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum CardType
 {
     [EnumMember(Value = "ALELO")]

--- a/src/SumUp/Models/Currency.g.cs
+++ b/src/SumUp/Models/Currency.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum Currency
 {
     [EnumMember(Value = "BGN")]

--- a/src/SumUp/Models/EntryMode.g.cs
+++ b/src/SumUp/Models/EntryMode.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum EntryMode
 {
     [EnumMember(Value = "none")]

--- a/src/SumUp/Models/EntryModeFilter.g.cs
+++ b/src/SumUp/Models/EntryModeFilter.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum EntryModeFilter
 {
     [EnumMember(Value = "BOLETO")]

--- a/src/SumUp/Models/EventStatus.g.cs
+++ b/src/SumUp/Models/EventStatus.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum EventStatus
 {
     [EnumMember(Value = "PENDING")]

--- a/src/SumUp/Models/EventType.g.cs
+++ b/src/SumUp/Models/EventType.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum EventType
 {
     [EnumMember(Value = "PAYOUT")]

--- a/src/SumUp/Models/MembershipStatus.g.cs
+++ b/src/SumUp/Models/MembershipStatus.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum MembershipStatus
 {
     [EnumMember(Value = "accepted")]

--- a/src/SumUp/Models/PaymentType.g.cs
+++ b/src/SumUp/Models/PaymentType.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum PaymentType
 {
     [EnumMember(Value = "CASH")]

--- a/src/SumUp/Models/ReaderStatus.g.cs
+++ b/src/SumUp/Models/ReaderStatus.g.cs
@@ -6,7 +6,7 @@ namespace SumUp;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(EnumMemberJsonConverterFactory))]
 public enum ReaderStatus
 {
     [EnumMember(Value = "unknown")]


### PR DESCRIPTION
Honor `EnumMember` values when serializing generated enums.

Add a shared enum converter for current target frameworks, update codegen to emit it for generated enums, and cover both standalone enum serialization and request payload serialization in tests.

Can be cleaned up, simlified with v10 onwards.

Fixes: https://github.com/sumup/sumup-dotnet/issues/57