### PR TITLE
fix: deserialize readOnly model properties

### DIFF
--- a/codegen/internal/generator/templates/model_class.tmpl
+++ b/codegen/internal/generator/templates/model_class.tmpl
@@ -31,7 +31,10 @@ public sealed partial class {{ .Name }}
     /// <summary>{{ .Description }}</summary>
 {{- end }}
     [JsonPropertyName("{{ .JsonName }}")]
-    public {{ .TypeName }} {{ .PropertyName }} { get;{{- if not .IsReadOnly }} set;{{- end }} }{{ if .NeedsInitializer }} = default!;{{ end }}
+{{- if .IsReadOnly }}
+    [JsonInclude]
+{{- end }}
+    public {{ .TypeName }} {{ .PropertyName }} { get;{{- if .IsReadOnly }} private{{- end }} set; }{{ if .NeedsInitializer }} = default!;{{ end }}
 {{- end }}
 {{- if .HasExtensionData }}
 

--- a/src/SumUp.Tests/ModelDeserializationTests.cs
+++ b/src/SumUp.Tests/ModelDeserializationTests.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using Xunit;
+
+namespace SumUp.Tests;
+
+public class ModelDeserializationTests
+{
+    [Fact]
+    public void Checkout_ReadOnlyId_IsDeserialized()
+    {
+        const string json = """
+            {
+              "id": "chk_123",
+              "amount": 10.0,
+              "checkout_reference": "order-123",
+              "currency": "EUR"
+            }
+            """;
+
+        var checkout = JsonSerializer.Deserialize<Checkout>(json);
+
+        Assert.NotNull(checkout);
+        Assert.Equal("chk_123", checkout!.Id);
+    }
+
+    [Fact]
+    public void CheckoutSuccess_ReadOnlyProperties_AreDeserialized()
+    {
+        const string json = """
+            {
+              "id": "chk_456",
+              "transaction_id": "tx_123",
+              "transaction_code": "ABC123",
+              "currency": "EUR"
+            }
+            """;
+
+        var checkout = JsonSerializer.Deserialize<CheckoutSuccess>(json);
+
+        Assert.NotNull(checkout);
+        Assert.Equal("chk_456", checkout!.Id);
+        Assert.Equal("tx_123", checkout.TransactionId);
+        Assert.Equal("ABC123", checkout.TransactionCode);
+    }
+}

--- a/src/SumUp/Models/BasePerson.g.cs
+++ b/src/SumUp/Models/BasePerson.g.cs
@@ -16,7 +16,8 @@ public sealed partial class BasePerson
     public DateTime? Birthdate { get; set; }
     /// <summary>Reflects the status of changes submitted through the `PATCH` endpoints for the merchant or persons. If some changes have not been applied yet, the status will be `pending`. If all changes have been applied, the status `done`. The status is only returned after write operations or on read endpoints when the `version` query parameter is provided.</summary>
     [JsonPropertyName("change_status")]
-    public string? ChangeStatus { get; }
+    [JsonInclude]
+    public string? ChangeStatus { get; private set; }
     /// <summary>An [ISO3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. This definition users `oneOf` with a two-character string type to allow for support of future countries in client code.</summary>
     [JsonPropertyName("citizenship")]
     public string? Citizenship { get; set; }
@@ -31,7 +32,8 @@ public sealed partial class BasePerson
     public string? GivenName { get; set; }
     /// <summary>The unique identifier for the person. This is a [typeid](https://github.com/sumup/typeid).</summary>
     [JsonPropertyName("id")]
-    public string Id { get; } = default!;
+    [JsonInclude]
+    public string Id { get; private set; } = default!;
     /// <summary>A list of country-specific personal identifiers.</summary>
     [JsonPropertyName("identifiers")]
     public IEnumerable<PersonalIdentifier>? Identifiers { get; set; }

--- a/src/SumUp/Models/Card.g.cs
+++ b/src/SumUp/Models/Card.g.cs
@@ -18,7 +18,8 @@ public sealed partial class Card
     public string ExpiryYear { get; set; } = default!;
     /// <summary>Last 4 digits of the payment card number.</summary>
     [JsonPropertyName("last_4_digits")]
-    public string Last4Digits { get; } = default!;
+    [JsonInclude]
+    public string Last4Digits { get; private set; } = default!;
     /// <summary>Name of the cardholder as it appears on the payment card.</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = default!;

--- a/src/SumUp/Models/CardResponse.g.cs
+++ b/src/SumUp/Models/CardResponse.g.cs
@@ -9,7 +9,8 @@ public sealed partial class CardResponse
 {
     /// <summary>Last 4 digits of the payment card number.</summary>
     [JsonPropertyName("last_4_digits")]
-    public string? Last4Digits { get; }
+    [JsonInclude]
+    public string? Last4Digits { get; private set; }
     /// <summary>Issuing card network of the payment card used for the transaction.</summary>
     [JsonPropertyName("type")]
     public CardType? Type { get; set; }

--- a/src/SumUp/Models/Checkout.g.cs
+++ b/src/SumUp/Models/Checkout.g.cs
@@ -28,7 +28,8 @@ public sealed partial class Checkout
     public string? Description { get; set; }
     /// <summary>Unique ID of the checkout resource.</summary>
     [JsonPropertyName("id")]
-    public string? Id { get; }
+    [JsonInclude]
+    public string? Id { get; private set; }
     /// <summary>Created mandate</summary>
     [JsonPropertyName("mandate")]
     public MandateResponse? Mandate { get; set; }

--- a/src/SumUp/Models/CheckoutCreateRequest.g.cs
+++ b/src/SumUp/Models/CheckoutCreateRequest.g.cs
@@ -22,13 +22,15 @@ public sealed partial class CheckoutCreateRequest
     public string? CustomerId { get; set; }
     /// <summary>Date and time of the creation of the payment checkout. Response format expressed according to [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) code.</summary>
     [JsonPropertyName("date")]
-    public DateTimeOffset? Date { get; }
+    [JsonInclude]
+    public DateTimeOffset? Date { get; private set; }
     /// <summary>Short description of the checkout visible in the SumUp dashboard. The description can contribute to reporting, allowing easier identification of a checkout.</summary>
     [JsonPropertyName("description")]
     public string? Description { get; set; }
     /// <summary>Unique ID of the checkout resource.</summary>
     [JsonPropertyName("id")]
-    public string? Id { get; }
+    [JsonInclude]
+    public string? Id { get; private set; }
     /// <summary>Unique identifying code of the merchant profile.</summary>
     [JsonPropertyName("merchant_code")]
     public string MerchantCode { get; set; } = default!;
@@ -43,10 +45,12 @@ public sealed partial class CheckoutCreateRequest
     public string? ReturnUrl { get; set; }
     /// <summary>Current status of the checkout.</summary>
     [JsonPropertyName("status")]
-    public string? Status { get; }
+    [JsonInclude]
+    public string? Status { get; private set; }
     /// <summary>List of transactions related to the payment.</summary>
     [JsonPropertyName("transactions")]
-    public IEnumerable<CheckoutCreateRequestTransactionsItem>? Transactions { get; }
+    [JsonInclude]
+    public IEnumerable<CheckoutCreateRequestTransactionsItem>? Transactions { get; private set; }
     /// <summary>Date and time of the checkout expiration before which the client application needs to send a processing request. If no value is present, the checkout does not have an expiration time.</summary>
     [JsonPropertyName("valid_until")]
     public DateTimeOffset? ValidUntil { get; set; }

--- a/src/SumUp/Models/CheckoutSuccess.g.cs
+++ b/src/SumUp/Models/CheckoutSuccess.g.cs
@@ -28,7 +28,8 @@ public sealed partial class CheckoutSuccess
     public string? Description { get; set; }
     /// <summary>Unique ID of the checkout resource.</summary>
     [JsonPropertyName("id")]
-    public string? Id { get; }
+    [JsonInclude]
+    public string? Id { get; private set; }
     /// <summary>Created mandate</summary>
     [JsonPropertyName("mandate")]
     public MandateResponse? Mandate { get; set; }
@@ -52,10 +53,12 @@ public sealed partial class CheckoutSuccess
     public string? Status { get; set; }
     /// <summary>Transaction code of the successful transaction with which the payment for the checkout is completed.</summary>
     [JsonPropertyName("transaction_code")]
-    public string? TransactionCode { get; }
+    [JsonInclude]
+    public string? TransactionCode { get; private set; }
     /// <summary>Transaction ID of the successful transaction with which the payment for the checkout is completed.</summary>
     [JsonPropertyName("transaction_id")]
-    public string? TransactionId { get; }
+    [JsonInclude]
+    public string? TransactionId { get; private set; }
     /// <summary>List of transactions related to the payment.</summary>
     [JsonPropertyName("transactions")]
     public IEnumerable<CheckoutSuccessTransactionsItem>? Transactions { get; set; }

--- a/src/SumUp/Models/Merchant.g.cs
+++ b/src/SumUp/Models/Merchant.g.cs
@@ -20,7 +20,8 @@ public sealed partial class Merchant
     public string? BusinessType { get; set; }
     /// <summary>Reflects the status of changes submitted through the `PATCH` endpoints for the merchant or persons. If some changes have not been applied yet, the status will be `pending`. If all changes have been applied, the status `done`. The status is only returned after write operations or on read endpoints when the `version` query parameter is provided.</summary>
     [JsonPropertyName("change_status")]
-    public string? ChangeStatus { get; }
+    [JsonInclude]
+    public string? ChangeStatus { get; private set; }
     [JsonPropertyName("classic")]
     public ClassicMerchantIdentifiers? Classic { get; set; }
     /// <summary>Information about the company or business. This is legal information that is used for verification.</summary>
@@ -31,16 +32,19 @@ public sealed partial class Merchant
     public string Country { get; set; } = default!;
     /// <summary>The date and time when the resource was created. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; } = default!;
+    [JsonInclude]
+    public DateTimeOffset CreatedAt { get; private set; } = default!;
     /// <summary>Three-letter [ISO currency code](https://en.wikipedia.org/wiki/ISO_4217) representing the default currency for the account.</summary>
     [JsonPropertyName("default_currency")]
-    public string DefaultCurrency { get; } = default!;
+    [JsonInclude]
+    public string DefaultCurrency { get; private set; } = default!;
     /// <summary>Merchant's default locale, represented as a BCP47 [RFC5646](https://datatracker.ietf.org/doc/html/rfc5646) language tag. This is typically an ISO 639-1 Alpha-2 [ISO639‑1](https://www.iso.org/iso-639-language-code) language code in lowercase and an ISO 3166-1 Alpha-2 [ISO3166‑1](https://www.iso.org/iso-3166-country-codes.html) country code in uppercase, separated by a dash. For example, en-US or fr-CA. In multilingual countries this is the merchant's preferred locale out of those, that are officially spoken in the country. In a countries with a single official language this will match the official language.</summary>
     [JsonPropertyName("default_locale")]
     public string DefaultLocale { get; set; } = default!;
     /// <summary>Short unique identifier for the merchant.</summary>
     [JsonPropertyName("merchant_code")]
-    public string MerchantCode { get; } = default!;
+    [JsonInclude]
+    public string MerchantCode { get; private set; } = default!;
     /// <summary>A set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. **Warning**: Updating Meta will overwrite the existing data. Make sure to always include the complete JSON object.</summary>
     [JsonPropertyName("meta")]
     public Meta? Meta { get; set; }
@@ -52,7 +56,8 @@ public sealed partial class Merchant
     public bool? Sandbox { get; set; }
     /// <summary>The date and time when the resource was last updated. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; } = default!;
+    [JsonInclude]
+    public DateTimeOffset UpdatedAt { get; private set; } = default!;
     /// <summary>The version of the resource. The version reflects a specific change submitted to the API via one of the `PATCH` endpoints.</summary>
     [JsonPropertyName("version")]
     public string? Version { get; set; }

--- a/src/SumUp/Models/PaymentInstrumentCard.g.cs
+++ b/src/SumUp/Models/PaymentInstrumentCard.g.cs
@@ -9,13 +9,15 @@ public sealed partial class PaymentInstrumentCard
 {
     /// <summary>Indicates whether the payment instrument is active and can be used for payments. To deactivate it, send a `DELETE` request to the resource endpoint.</summary>
     [JsonPropertyName("active")]
-    public bool Active { get; }
+    [JsonInclude]
+    public bool Active { get; private set; }
     /// <summary>__Required when payment type is `card`.__ Details of the payment card.</summary>
     [JsonPropertyName("card")]
     public Card Card { get; set; } = default!;
     /// <summary>Unique token identifying the saved payment card for a customer.</summary>
     [JsonPropertyName("token")]
-    public string Token { get; } = default!;
+    [JsonInclude]
+    public string Token { get; private set; } = default!;
     /// <summary>Type of the payment instrument.</summary>
     [JsonPropertyName("type")]
     public string Type { get; set; } = default!;

--- a/src/SumUp/Models/PaymentInstrumentResponse.g.cs
+++ b/src/SumUp/Models/PaymentInstrumentResponse.g.cs
@@ -9,7 +9,8 @@ public sealed partial class PaymentInstrumentResponse
 {
     /// <summary>Indicates whether the payment instrument is active and can be used for payments. To deactivate it, send a `DELETE` request to the resource endpoint.</summary>
     [JsonPropertyName("active")]
-    public bool? Active { get; }
+    [JsonInclude]
+    public bool? Active { get; private set; }
     /// <summary>Details of the payment card.</summary>
     [JsonPropertyName("card")]
     public PaymentInstrumentResponseCard? Card { get; set; }
@@ -21,7 +22,8 @@ public sealed partial class PaymentInstrumentResponse
     public MandateResponse? Mandate { get; set; }
     /// <summary>Unique token identifying the saved payment card for a customer.</summary>
     [JsonPropertyName("token")]
-    public string? Token { get; }
+    [JsonInclude]
+    public string? Token { get; private set; }
     /// <summary>Type of the payment instrument.</summary>
     [JsonPropertyName("type")]
     public string? Type { get; set; }

--- a/src/SumUp/Models/PaymentInstrumentResponseCard.g.cs
+++ b/src/SumUp/Models/PaymentInstrumentResponseCard.g.cs
@@ -9,7 +9,8 @@ public sealed partial class PaymentInstrumentResponseCard
 {
     /// <summary>Last 4 digits of the payment card number.</summary>
     [JsonPropertyName("last_4_digits")]
-    public string? Last4Digits { get; }
+    [JsonInclude]
+    public string? Last4Digits { get; private set; }
     /// <summary>Issuing card network of the payment card used for the transaction.</summary>
     [JsonPropertyName("type")]
     public CardType? Type { get; set; }

--- a/src/SumUp/Models/Person.g.cs
+++ b/src/SumUp/Models/Person.g.cs
@@ -15,7 +15,8 @@ public sealed partial class Person
     public DateTime? Birthdate { get; set; }
     /// <summary>Reflects the status of changes submitted through the `PATCH` endpoints for the merchant or persons. If some changes have not been applied yet, the status will be `pending`. If all changes have been applied, the status `done`. The status is only returned after write operations or on read endpoints when the `version` query parameter is provided.</summary>
     [JsonPropertyName("change_status")]
-    public string? ChangeStatus { get; }
+    [JsonInclude]
+    public string? ChangeStatus { get; private set; }
     /// <summary>An [ISO3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. This definition users `oneOf` with a two-character string type to allow for support of future countries in client code.</summary>
     [JsonPropertyName("citizenship")]
     public string? Citizenship { get; set; }
@@ -30,7 +31,8 @@ public sealed partial class Person
     public string? GivenName { get; set; }
     /// <summary>The unique identifier for the person. This is a [typeid](https://github.com/sumup/typeid).</summary>
     [JsonPropertyName("id")]
-    public string Id { get; } = default!;
+    [JsonInclude]
+    public string Id { get; private set; } = default!;
     /// <summary>A list of country-specific personal identifiers.</summary>
     [JsonPropertyName("identifiers")]
     public IEnumerable<PersonalIdentifier>? Identifiers { get; set; }

--- a/src/SumUp/Models/Timestamps.g.cs
+++ b/src/SumUp/Models/Timestamps.g.cs
@@ -8,8 +8,10 @@ public sealed partial class Timestamps
 {
     /// <summary>The date and time when the resource was created. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; } = default!;
+    [JsonInclude]
+    public DateTimeOffset CreatedAt { get; private set; } = default!;
     /// <summary>The date and time when the resource was last updated. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; } = default!;
+    [JsonInclude]
+    public DateTimeOffset UpdatedAt { get; private set; } = default!;
 }


### PR DESCRIPTION
Emit `[JsonInclude]` with private setters for generated `readOnly` properties.

Fixes #60