### PR TITLE
fix(sdk): date-only and time-only types

### DIFF
--- a/codegen/internal/generator/generator.go
+++ b/codegen/internal/generator/generator.go
@@ -1229,17 +1229,24 @@ func (g *Generator) resolveType(schemaRef *base.SchemaProxy, required bool) type
 	switch {
 	case schemaHasType(schema, "string"):
 		typeName := "string"
+		isValueType := false
 		switch schema.Format {
 		case "date-time":
 			typeName = "DateTimeOffset"
+			isValueType = true
 		case "date":
-			typeName = "DateTime"
+			typeName = "DateOnly"
+			isValueType = true
+		case "time", "partial-time":
+			typeName = "TimeOnly"
+			isValueType = true
 		case "uuid":
 			typeName = "Guid"
+			isValueType = true
 		case "byte", "binary":
 			typeName = "byte[]"
 		}
-		return g.nullableType(typeName, false, required)
+		return g.nullableType(typeName, isValueType, required)
 	case schemaHasType(schema, "integer"):
 		typeName := "int"
 		if schema.Format == "int64" {

--- a/src/SumUp.Tests/ModelDeserializationTests.cs
+++ b/src/SumUp.Tests/ModelDeserializationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using Xunit;
 
@@ -41,5 +42,20 @@ public class ModelDeserializationTests
         Assert.Equal("chk_456", checkout!.Id);
         Assert.Equal("tx_123", checkout.TransactionId);
         Assert.Equal("ABC123", checkout.TransactionCode);
+    }
+
+    [Fact]
+    public void PersonalDetails_DateOnlyProperties_AreDeserialized()
+    {
+        const string json = """
+            {
+              "birth_date": "1980-01-12"
+            }
+            """;
+
+        var personalDetails = JsonSerializer.Deserialize<PersonalDetails>(json);
+
+        Assert.NotNull(personalDetails);
+        Assert.Equal(new DateOnly(1980, 1, 12), personalDetails!.BirthDate);
     }
 }

--- a/src/SumUp.Tests/RequestBuilderTests.cs
+++ b/src/SumUp.Tests/RequestBuilderTests.cs
@@ -71,6 +71,16 @@ public class RequestBuilderTests
     }
 
     [Fact]
+    public void Build_SerializesDateOnlyQueryUsingIsoFormat()
+    {
+        var builder = new RequestBuilder(HttpMethod.Get, "/v0.1/items", new Uri("https://api.sumup.com"));
+        builder.AddQuery("birthdate", new DateOnly(1980, 1, 12));
+        var request = builder.Build();
+
+        Assert.Equal("https://api.sumup.com/v0.1/items?birthdate=1980-01-12", request.RequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
     public void CreateContent_SerializesEnumMemberValues()
     {
         using var httpClient = new HttpClient { BaseAddress = new Uri("https://api.sumup.com") };
@@ -90,5 +100,23 @@ public class RequestBuilderTests
         var body = reader.ReadToEnd();
 
         Assert.Contains("\"currency\":\"EUR\"", body);
+    }
+
+    [Fact]
+    public void CreateContent_SerializesDateOnlyValues()
+    {
+        using var httpClient = new HttpClient { BaseAddress = new Uri("https://api.sumup.com") };
+        var apiClient = new ApiClient(httpClient, new SumUpClientOptions());
+        var request = new PersonalDetails
+        {
+            BirthDate = new DateOnly(1980, 1, 12)
+        };
+
+        using var content = apiClient.CreateContent(request, "application/json");
+        using var stream = content.ReadAsStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var body = reader.ReadToEnd();
+
+        Assert.Contains("\"birth_date\":\"1980-01-12\"", body);
     }
 }

--- a/src/SumUp/Http/RequestBuilder.cs
+++ b/src/SumUp/Http/RequestBuilder.cs
@@ -149,6 +149,26 @@ internal sealed class RequestBuilder
 
     private static string ConvertToString(object value)
     {
+        if (value is DateOnly dateOnly)
+        {
+            return dateOnly.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        }
+
+        if (value is TimeOnly timeOnly)
+        {
+            return timeOnly.ToString(@"HH\:mm\:ss\.FFFFFFF", CultureInfo.InvariantCulture).TrimEnd('0').TrimEnd('.');
+        }
+
+        if (value is DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString("O", CultureInfo.InvariantCulture);
+        }
+
+        if (value is DateTime dateTime)
+        {
+            return dateTime.ToString("O", CultureInfo.InvariantCulture);
+        }
+
         var type = value.GetType();
         if (type.IsEnum)
         {

--- a/src/SumUp/Models/BasePerson.g.cs
+++ b/src/SumUp/Models/BasePerson.g.cs
@@ -13,7 +13,7 @@ public sealed partial class BasePerson
     public Address? Address { get; set; }
     /// <summary>The date of birth of the individual, represented as an ISO 8601:2004 [ISO8601‑2004] YYYY-MM-DD format.</summary>
     [JsonPropertyName("birthdate")]
-    public DateTime? Birthdate { get; set; }
+    public DateOnly? Birthdate { get; set; }
     /// <summary>Reflects the status of changes submitted through the `PATCH` endpoints for the merchant or persons. If some changes have not been applied yet, the status will be `pending`. If all changes have been applied, the status `done`. The status is only returned after write operations or on read endpoints when the `version` query parameter is provided.</summary>
     [JsonPropertyName("change_status")]
     [JsonInclude]

--- a/src/SumUp/Models/FinancialPayoutsItem.g.cs
+++ b/src/SumUp/Models/FinancialPayoutsItem.g.cs
@@ -11,7 +11,7 @@ public sealed partial class FinancialPayoutsItem
     [JsonPropertyName("currency")]
     public string? Currency { get; set; }
     [JsonPropertyName("date")]
-    public DateTime? Date { get; set; }
+    public DateOnly? Date { get; set; }
     [JsonPropertyName("fee")]
     public float? Fee { get; set; }
     [JsonPropertyName("id")]

--- a/src/SumUp/Models/Invite.g.cs
+++ b/src/SumUp/Models/Invite.g.cs
@@ -11,5 +11,5 @@ public sealed partial class Invite
     [JsonPropertyName("email")]
     public string Email { get; set; } = default!;
     [JsonPropertyName("expires_at")]
-    public DateTimeOffset ExpiresAt { get; set; } = default!;
+    public DateTimeOffset ExpiresAt { get; set; }
 }

--- a/src/SumUp/Models/Member.g.cs
+++ b/src/SumUp/Models/Member.g.cs
@@ -13,7 +13,7 @@ public sealed partial class Member
     public Attributes? Attributes { get; set; }
     /// <summary>The timestamp of when the member was created.</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; set; } = default!;
+    public DateTimeOffset CreatedAt { get; set; }
     /// <summary>ID of the member.</summary>
     [JsonPropertyName("id")]
     public string Id { get; set; } = default!;
@@ -34,7 +34,7 @@ public sealed partial class Member
     public MembershipStatus Status { get; set; }
     /// <summary>The timestamp of when the member was last updated.</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; set; } = default!;
+    public DateTimeOffset UpdatedAt { get; set; }
     /// <summary>Information about the user associated with the membership.</summary>
     [JsonPropertyName("user")]
     public MembershipUser? User { get; set; }

--- a/src/SumUp/Models/Membership.g.cs
+++ b/src/SumUp/Models/Membership.g.cs
@@ -13,7 +13,7 @@ public sealed partial class Membership
     public Attributes? Attributes { get; set; }
     /// <summary>The timestamp of when the membership was created.</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; set; } = default!;
+    public DateTimeOffset CreatedAt { get; set; }
     /// <summary>ID of the membership.</summary>
     [JsonPropertyName("id")]
     public string Id { get; set; } = default!;
@@ -43,5 +43,5 @@ public sealed partial class Membership
     public string Type { get; set; } = default!;
     /// <summary>The timestamp of when the membership was last updated.</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; set; } = default!;
+    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/src/SumUp/Models/MembershipResource.g.cs
+++ b/src/SumUp/Models/MembershipResource.g.cs
@@ -12,7 +12,7 @@ public sealed partial class MembershipResource
     public Attributes? Attributes { get; set; }
     /// <summary>The timestamp of when the membership resource was created.</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; set; } = default!;
+    public DateTimeOffset CreatedAt { get; set; }
     /// <summary>ID of the resource the membership is in.</summary>
     [JsonPropertyName("id")]
     public string Id { get; set; } = default!;
@@ -27,5 +27,5 @@ public sealed partial class MembershipResource
     public string Type { get; set; } = default!;
     /// <summary>The timestamp of when the membership resource was last updated.</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; set; } = default!;
+    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/src/SumUp/Models/Merchant.g.cs
+++ b/src/SumUp/Models/Merchant.g.cs
@@ -33,7 +33,7 @@ public sealed partial class Merchant
     /// <summary>The date and time when the resource was created. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("created_at")]
     [JsonInclude]
-    public DateTimeOffset CreatedAt { get; private set; } = default!;
+    public DateTimeOffset CreatedAt { get; private set; }
     /// <summary>Three-letter [ISO currency code](https://en.wikipedia.org/wiki/ISO_4217) representing the default currency for the account.</summary>
     [JsonPropertyName("default_currency")]
     [JsonInclude]
@@ -57,7 +57,7 @@ public sealed partial class Merchant
     /// <summary>The date and time when the resource was last updated. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("updated_at")]
     [JsonInclude]
-    public DateTimeOffset UpdatedAt { get; private set; } = default!;
+    public DateTimeOffset UpdatedAt { get; private set; }
     /// <summary>The version of the resource. The version reflects a specific change submitted to the API via one of the `PATCH` endpoints.</summary>
     [JsonPropertyName("version")]
     public string? Version { get; set; }

--- a/src/SumUp/Models/OperatorValue.g.cs
+++ b/src/SumUp/Models/OperatorValue.g.cs
@@ -11,7 +11,7 @@ public sealed partial class OperatorValue
     public OperatorValueAccountType AccountType { get; set; }
     /// <summary>The timestamp of when the operator was created.</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; set; } = default!;
+    public DateTimeOffset CreatedAt { get; set; }
     [JsonPropertyName("disabled")]
     public bool Disabled { get; set; }
     [JsonPropertyName("id")]
@@ -23,7 +23,7 @@ public sealed partial class OperatorValue
     public Permissions Permissions { get; set; } = default!;
     /// <summary>The timestamp of when the operator was last updated.</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; set; } = default!;
+    public DateTimeOffset UpdatedAt { get; set; }
     [JsonPropertyName("username")]
     public string Username { get; set; } = default!;
 }

--- a/src/SumUp/Models/Person.g.cs
+++ b/src/SumUp/Models/Person.g.cs
@@ -12,7 +12,7 @@ public sealed partial class Person
     public Address? Address { get; set; }
     /// <summary>The date of birth of the individual, represented as an ISO 8601:2004 [ISO8601‑2004] YYYY-MM-DD format.</summary>
     [JsonPropertyName("birthdate")]
-    public DateTime? Birthdate { get; set; }
+    public DateOnly? Birthdate { get; set; }
     /// <summary>Reflects the status of changes submitted through the `PATCH` endpoints for the merchant or persons. If some changes have not been applied yet, the status will be `pending`. If all changes have been applied, the status `done`. The status is only returned after write operations or on read endpoints when the `version` query parameter is provided.</summary>
     [JsonPropertyName("change_status")]
     [JsonInclude]

--- a/src/SumUp/Models/PersonalDetails.g.cs
+++ b/src/SumUp/Models/PersonalDetails.g.cs
@@ -12,7 +12,7 @@ public sealed partial class PersonalDetails
     public AddressLegacy? Address { get; set; }
     /// <summary>Date of birth of the customer.</summary>
     [JsonPropertyName("birth_date")]
-    public DateTime? BirthDate { get; set; }
+    public DateOnly? BirthDate { get; set; }
     /// <summary>Email address of the customer.</summary>
     [JsonPropertyName("email")]
     public string? Email { get; set; }

--- a/src/SumUp/Models/PersonalProfilePayloadLegacy.g.cs
+++ b/src/SumUp/Models/PersonalProfilePayloadLegacy.g.cs
@@ -12,7 +12,7 @@ public sealed partial class PersonalProfilePayloadLegacy
     public AddressPayloadLegacy Address { get; set; } = default!;
     /// <summary>Date of birth</summary>
     [JsonPropertyName("date_of_birth")]
-    public DateTime DateOfBirth { get; set; } = default!;
+    public DateOnly DateOfBirth { get; set; }
     /// <summary>First name of the user</summary>
     [JsonPropertyName("first_name")]
     public string FirstName { get; set; } = default!;

--- a/src/SumUp/Models/Reader.g.cs
+++ b/src/SumUp/Models/Reader.g.cs
@@ -9,7 +9,7 @@ public sealed partial class Reader
 {
     /// <summary>The timestamp of when the reader was created.</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; set; } = default!;
+    public DateTimeOffset CreatedAt { get; set; }
     /// <summary>Information about the underlying physical device.</summary>
     [JsonPropertyName("device")]
     public ReaderDevice Device { get; set; } = default!;
@@ -30,5 +30,5 @@ public sealed partial class Reader
     public ReaderStatus Status { get; set; }
     /// <summary>The timestamp of when the reader was last updated.</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; set; } = default!;
+    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/src/SumUp/Models/ReaderCheckoutStatusChange.g.cs
+++ b/src/SumUp/Models/ReaderCheckoutStatusChange.g.cs
@@ -12,11 +12,11 @@ public sealed partial class ReaderCheckoutStatusChange
     public string EventType { get; set; } = default!;
     /// <summary>Unique identifier for the event.</summary>
     [JsonPropertyName("id")]
-    public Guid Id { get; set; } = default!;
+    public Guid Id { get; set; }
     /// <summary>The event payload.</summary>
     [JsonPropertyName("payload")]
     public ReaderCheckoutStatusChangePayload Payload { get; set; } = default!;
     /// <summary>Timestamp of the event.</summary>
     [JsonPropertyName("timestamp")]
-    public DateTimeOffset Timestamp { get; set; } = default!;
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/src/SumUp/Models/ReaderCheckoutStatusChangePayload.g.cs
+++ b/src/SumUp/Models/ReaderCheckoutStatusChangePayload.g.cs
@@ -9,7 +9,7 @@ public sealed partial class ReaderCheckoutStatusChangePayload
 {
     /// <summary>The unique client transaction id. It is the same returned by the Checkout.</summary>
     [JsonPropertyName("client_transaction_id")]
-    public Guid ClientTransactionId { get; set; } = default!;
+    public Guid ClientTransactionId { get; set; }
     /// <summary>The merchant code associated with the transaction.</summary>
     [JsonPropertyName("merchant_code")]
     public string MerchantCode { get; set; } = default!;

--- a/src/SumUp/Models/Role.g.cs
+++ b/src/SumUp/Models/Role.g.cs
@@ -10,7 +10,7 @@ public sealed partial class Role
 {
     /// <summary>The timestamp of when the role was created.</summary>
     [JsonPropertyName("created_at")]
-    public DateTimeOffset CreatedAt { get; set; } = default!;
+    public DateTimeOffset CreatedAt { get; set; }
     /// <summary>User-defined description of the role.</summary>
     [JsonPropertyName("description")]
     public string? Description { get; set; }
@@ -31,5 +31,5 @@ public sealed partial class Role
     public IEnumerable<string> Permissions { get; set; } = default!;
     /// <summary>The timestamp of when the role was last updated.</summary>
     [JsonPropertyName("updated_at")]
-    public DateTimeOffset UpdatedAt { get; set; } = default!;
+    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/src/SumUp/Models/Timestamps.g.cs
+++ b/src/SumUp/Models/Timestamps.g.cs
@@ -9,9 +9,9 @@ public sealed partial class Timestamps
     /// <summary>The date and time when the resource was created. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("created_at")]
     [JsonInclude]
-    public DateTimeOffset CreatedAt { get; private set; } = default!;
+    public DateTimeOffset CreatedAt { get; private set; }
     /// <summary>The date and time when the resource was last updated. This is a string as defined in [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).</summary>
     [JsonPropertyName("updated_at")]
     [JsonInclude]
-    public DateTimeOffset UpdatedAt { get; private set; } = default!;
+    public DateTimeOffset UpdatedAt { get; private set; }
 }

--- a/src/SumUp/Models/TransactionEvent.g.cs
+++ b/src/SumUp/Models/TransactionEvent.g.cs
@@ -12,10 +12,10 @@ public sealed partial class TransactionEvent
     public decimal? Amount { get; set; }
     /// <summary>Date when the transaction event occurred.</summary>
     [JsonPropertyName("date")]
-    public DateTime? Date { get; set; }
+    public DateOnly? Date { get; set; }
     /// <summary>Date when the transaction event is due to occur.</summary>
     [JsonPropertyName("due_date")]
-    public DateTime? DueDate { get; set; }
+    public DateOnly? DueDate { get; set; }
     /// <summary>Type of the transaction event.</summary>
     [JsonPropertyName("event_type")]
     public EventType? EventType { get; set; }

--- a/src/SumUp/Models/TransactionFull.g.cs
+++ b/src/SumUp/Models/TransactionFull.g.cs
@@ -79,7 +79,7 @@ public sealed partial class TransactionFull
     public PaymentType? PaymentType { get; set; }
     /// <summary>The date of the payout.</summary>
     [JsonPropertyName("payout_date")]
-    public DateTime? PayoutDate { get; set; }
+    public DateOnly? PayoutDate { get; set; }
     /// <summary>Payout plan of the registered user at the time when the transaction was made.</summary>
     [JsonPropertyName("payout_plan")]
     public TransactionFullPayoutPlan? PayoutPlan { get; set; }

--- a/src/SumUp/Models/TransactionHistory.g.cs
+++ b/src/SumUp/Models/TransactionHistory.g.cs
@@ -30,7 +30,7 @@ public sealed partial class TransactionHistory
     public PaymentType? PaymentType { get; set; }
     /// <summary>Payout date (if paid out at once).</summary>
     [JsonPropertyName("payout_date")]
-    public DateTime? PayoutDate { get; set; }
+    public DateOnly? PayoutDate { get; set; }
     /// <summary>Payout plan of the registered user at the time when the transaction was made.</summary>
     [JsonPropertyName("payout_plan")]
     public TransactionHistoryPayoutPlan? PayoutPlan { get; set; }

--- a/src/SumUp/PayoutsClient.g.cs
+++ b/src/SumUp/PayoutsClient.g.cs
@@ -36,7 +36,7 @@ public sealed partial class PayoutsClient
     /// <param name="order">Request parameter.</param>
     /// <param name="requestOptions">Optional per-request overrides.</param>
     /// <param name="cancellationToken">Token used to cancel the request.</param>
-    public ApiResponse<IEnumerable<FinancialPayoutsItem>> List(string merchantCode, DateTime startDate, DateTime endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+    public ApiResponse<IEnumerable<FinancialPayoutsItem>> List(string merchantCode, DateOnly startDate, DateOnly endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
     {
         var request = _client.CreateRequest(HttpMethod.Get, "/v1.0/merchants/{merchant_code}/payouts", builder =>
         {
@@ -100,7 +100,7 @@ public sealed partial class PayoutsClient
     /// <param name="order">Request parameter.</param>
     /// <param name="requestOptions">Optional per-request overrides.</param>
     /// <param name="cancellationToken">Token used to cancel the request.</param>
-    public async Task<ApiResponse<IEnumerable<FinancialPayoutsItem>>> ListAsync(string merchantCode, DateTime startDate, DateTime endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+    public async Task<ApiResponse<IEnumerable<FinancialPayoutsItem>>> ListAsync(string merchantCode, DateOnly startDate, DateOnly endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
     {
         var request = _client.CreateRequest(HttpMethod.Get, "/v1.0/merchants/{merchant_code}/payouts", builder =>
         {
@@ -163,7 +163,7 @@ public sealed partial class PayoutsClient
     /// <param name="order">Request parameter.</param>
     /// <param name="requestOptions">Optional per-request overrides.</param>
     /// <param name="cancellationToken">Token used to cancel the request.</param>
-    public ApiResponse<IEnumerable<FinancialPayoutsItem>> ListDeprecated(DateTime startDate, DateTime endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+    public ApiResponse<IEnumerable<FinancialPayoutsItem>> ListDeprecated(DateOnly startDate, DateOnly endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
     {
         var request = _client.CreateRequest(HttpMethod.Get, "/v0.1/me/financials/payouts", builder =>
         {
@@ -225,7 +225,7 @@ public sealed partial class PayoutsClient
     /// <param name="order">Request parameter.</param>
     /// <param name="requestOptions">Optional per-request overrides.</param>
     /// <param name="cancellationToken">Token used to cancel the request.</param>
-    public async Task<ApiResponse<IEnumerable<FinancialPayoutsItem>>> ListDeprecatedAsync(DateTime startDate, DateTime endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+    public async Task<ApiResponse<IEnumerable<FinancialPayoutsItem>>> ListDeprecatedAsync(DateOnly startDate, DateOnly endDate, string? format = null, int? limit = null, string? order = null, RequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
     {
         var request = _client.CreateRequest(HttpMethod.Get, "/v0.1/me/financials/payouts", builder =>
         {

--- a/src/SumUp/SumUp.csproj
+++ b/src/SumUp/SumUp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
@@ -22,10 +22,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="10.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" Link="README.md" />


### PR DESCRIPTION
Handle correctly date-only and time-only types and their serialization.

Drops support for `netstandard2.0` as it made the solution way more complex.

Related: https://github.com/sumup/sumup-dotnet/issues/86
