### PR TITLE
refactor(sdk): narrow deserialization error handling

### DIFF
--- a/src/SumUp.Tests/RequestBuilderTests.cs
+++ b/src/SumUp.Tests/RequestBuilderTests.cs
@@ -119,4 +119,24 @@ public class RequestBuilderTests
 
         Assert.Contains("\"birth_date\":\"1980-01-12\"", body);
     }
+
+    [Fact]
+    public void TryDeserialize_ReturnsDefaultForMalformedJson()
+    {
+        using var httpClient = new HttpClient { BaseAddress = new Uri("https://api.sumup.com") };
+        var apiClient = new ApiClient(httpClient, new SumUpClientOptions());
+
+        var result = apiClient.TryDeserialize<Checkout>("{");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDeserialize_PropagatesNonJsonExceptions()
+    {
+        using var httpClient = new HttpClient { BaseAddress = new Uri("https://api.sumup.com") };
+        var apiClient = new ApiClient(httpClient, new SumUpClientOptions());
+
+        Assert.Throws<NotSupportedException>(() => apiClient.TryDeserialize<Type>("\"System.String\""));
+    }
 }

--- a/src/SumUp/Http/ApiClient.cs
+++ b/src/SumUp/Http/ApiClient.cs
@@ -91,7 +91,7 @@ internal sealed class ApiClient
         {
             return JsonSerializer.Deserialize<TModel>(payload!, _serializerOptions);
         }
-        catch
+        catch (JsonException)
         {
             return default;
         }


### PR DESCRIPTION
Only suppress JSON parsing failures in `ApiClient.TryDeserialize`
instead of swallowing all exceptions. This keeps malformed API
payloads non-fatal while allowing unrelated runtime errors to
surface instead of being hidden behind default values.

Add tests covering both malformed JSON fallback behavior and
propagation of non-JSON exceptions.
