### PR TITLE
feat(sdk): clarify opaque JSON handling in generated request and response types

### DIFF
--- a/codegen/internal/generator/generator.go
+++ b/codegen/internal/generator/generator.go
@@ -30,6 +30,14 @@ const (
 	schemaKindEnum
 )
 
+type schemaUsage int
+
+const (
+	schemaUsageModel schemaUsage = iota
+	schemaUsageRequest
+	schemaUsageResponse
+)
+
 type schemaTypeInfo struct {
 	Name             string
 	TypeName         string
@@ -900,15 +908,19 @@ func (g *Generator) buildRequestBody(clientName, methodName string, body *v3.Req
 }
 
 func (g *Generator) resolveRequestBodyType(schemaRef *base.SchemaProxy, required bool, clientName, methodName string) (typeInfo, error) {
-	return g.resolveInlineSchemaType(schemaRef, required, fmt.Sprintf("%s%sRequest", clientName, methodName))
+	return g.resolveInlineSchemaTypeForUsage(schemaRef, required, fmt.Sprintf("%s%sRequest", clientName, methodName), schemaUsageRequest)
 }
 
 func (g *Generator) resolvePropertyType(ownerName, propertyName string, schemaRef *base.SchemaProxy, required bool) (typeInfo, error) {
 	inlineBase := fmt.Sprintf("%s%s", ownerName, naming.PascalIdentifier(propertyName))
-	return g.resolveInlineSchemaType(schemaRef, required, inlineBase)
+	return g.resolveInlineSchemaTypeForUsage(schemaRef, required, inlineBase, schemaUsageModel)
 }
 
 func (g *Generator) resolveInlineSchemaType(schemaRef *base.SchemaProxy, required bool, inlineBase string) (typeInfo, error) {
+	return g.resolveInlineSchemaTypeForUsage(schemaRef, required, inlineBase, schemaUsageModel)
+}
+
+func (g *Generator) resolveInlineSchemaTypeForUsage(schemaRef *base.SchemaProxy, required bool, inlineBase string, usage schemaUsage) (typeInfo, error) {
 	if schemaRef == nil {
 		return g.nullableType("JsonDocument", false, required), nil
 	}
@@ -929,7 +941,7 @@ func (g *Generator) resolveInlineSchemaType(schemaRef *base.SchemaProxy, require
 			return g.nullableType(typeName, false, required), nil
 		}
 		if schema.AdditionalProperties != nil && schema.AdditionalProperties.IsA() && schema.AdditionalProperties.A != nil {
-			valueInfo, err := g.resolveInlineSchemaType(schema.AdditionalProperties.A, true, inlineBase+"Value")
+			valueInfo, err := g.resolveInlineSchemaTypeForUsage(schema.AdditionalProperties.A, true, inlineBase+"Value", usage)
 			if err != nil {
 				return typeInfo{}, err
 			}
@@ -938,10 +950,10 @@ func (g *Generator) resolveInlineSchemaType(schemaRef *base.SchemaProxy, require
 			return g.nullableType(typeName, false, required, true), nil
 		}
 		if schema.AdditionalProperties != nil && schema.AdditionalProperties.IsB() && schema.AdditionalProperties.B {
-			return g.nullableType("JsonObject", false, required), nil
+			return g.opaqueObjectType(required, usage), nil
 		}
 		if schema.Items != nil && schema.Items.IsA() {
-			itemInfo, err := g.resolveInlineSchemaType(schema.Items.A, true, inlineBase+"Item")
+			itemInfo, err := g.resolveInlineSchemaTypeForUsage(schema.Items.A, true, inlineBase+"Item", usage)
 			if err != nil {
 				return typeInfo{}, err
 			}
@@ -949,8 +961,30 @@ func (g *Generator) resolveInlineSchemaType(schemaRef *base.SchemaProxy, require
 			typeName := fmt.Sprintf("IEnumerable<%s>", itemName)
 			return g.nullableType(typeName, false, required, true), nil
 		}
+		if isOpaqueObjectSchema(schema) {
+			return g.opaqueObjectType(required, usage), nil
+		}
 	}
 	return g.resolveType(schemaRef, required), nil
+}
+
+func isOpaqueObjectSchema(schema *base.Schema) bool {
+	if schema == nil {
+		return false
+	}
+	if !schemaHasType(schema, "object") {
+		return false
+	}
+	if schema.Properties != nil && schema.Properties.Len() > 0 {
+		return false
+	}
+	if len(schema.AllOf) > 0 {
+		return false
+	}
+	if schema.AdditionalProperties != nil {
+		return false
+	}
+	return true
 }
 
 func schemaDefinesStructuredObject(schema *base.Schema) bool {
@@ -1156,29 +1190,7 @@ func (g *Generator) responseTypeForResponse(resp *v3.Response, inlineBase string
 	if schemaRef == nil {
 		return typeInfo{}, nil
 	}
-	if schema := g.schemaFromProxy(schemaRef); schema != nil && isOpaqueObjectSchema(schema) {
-		return g.nullableType("JsonDocument", false, true), nil
-	}
-	return g.resolveInlineSchemaType(schemaRef, true, inlineBase)
-}
-
-func isOpaqueObjectSchema(schema *base.Schema) bool {
-	if schema == nil {
-		return false
-	}
-	if !schemaHasType(schema, "object") {
-		return false
-	}
-	if schema.Properties != nil && schema.Properties.Len() > 0 {
-		return false
-	}
-	if len(schema.AllOf) > 0 {
-		return false
-	}
-	if schema.AdditionalProperties != nil {
-		return false
-	}
-	return true
+	return g.resolveInlineSchemaTypeForUsage(schemaRef, true, inlineBase, schemaUsageResponse)
 }
 
 func (g *Generator) resolveResponseMode(op *v3.Operation, responseInfo typeInfo) (string, error) {
@@ -1406,14 +1418,23 @@ func (g *Generator) resolveType(schemaRef *base.SchemaProxy, required bool) type
 			return g.nullableType(typeName, false, required, true)
 		}
 		if schema.AdditionalProperties != nil && schema.AdditionalProperties.IsB() && schema.AdditionalProperties.B {
-			return g.nullableType("JsonObject", false, required)
+			return g.opaqueObjectType(required, schemaUsageModel)
 		}
 		if (schema.Properties == nil || schema.Properties.Len() == 0) && len(schema.AllOf) == 0 {
-			return g.nullableType("JsonObject", false, required)
+			return g.opaqueObjectType(required, schemaUsageModel)
 		}
 		return g.nullableType("JsonDocument", false, required)
 	default:
 		return g.nullableType("JsonDocument", false, required)
+	}
+}
+
+func (g *Generator) opaqueObjectType(required bool, usage schemaUsage) typeInfo {
+	switch usage {
+	case schemaUsageResponse:
+		return g.nullableType("JsonDocument", false, required)
+	default:
+		return g.nullableType("JsonObject", false, required)
 	}
 }
 

--- a/codegen/internal/generator/generator_test.go
+++ b/codegen/internal/generator/generator_test.go
@@ -135,6 +135,57 @@ func TestBuildModels_UsesJsonObjectForFreeFormObjects(t *testing.T) {
 	}
 }
 
+func TestBuildRequestBody_UsesJsonObjectForOpaqueObjectRequests(t *testing.T) {
+	const spec = `{
+	  "openapi": "3.0.3",
+	  "info": {
+	    "title": "test",
+	    "version": "1.0.0"
+	  },
+	  "paths": {
+	    "/v0.2/checkouts/{id}/apple-pay-session": {
+	      "put": {
+	        "tags": ["Checkouts"],
+	        "operationId": "CreateApplePaySession",
+	        "requestBody": {
+	          "content": {
+	            "application/json": {
+	              "schema": { "type": "object" }
+	            }
+	          }
+	        },
+	        "responses": {
+	          "200": {
+	            "description": "ok",
+	            "content": {
+	              "application/json": {
+	                "schema": { "type": "string" }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	doc := mustBuildV3Document(t, spec)
+
+	g := New(Config{Namespace: "SumUp"})
+	clients, err := g.buildClients(doc)
+	if err != nil {
+		t.Fatalf("buildClients() error = %v", err)
+	}
+
+	operation := clients[0].Operations[0]
+	if operation.Body == nil {
+		t.Fatalf("request body should not be nil")
+	}
+	if operation.Body.TypeName != "JsonObject?" {
+		t.Fatalf("request body type = %q, want %q", operation.Body.TypeName, "JsonObject?")
+	}
+}
+
 func TestBuildClients_UsesJsonDocumentForOpaqueObjectResponses(t *testing.T) {
 	const spec = `{
 	  "openapi": "3.0.3",
@@ -188,6 +239,66 @@ func TestBuildClients_UsesJsonDocumentForOpaqueObjectResponses(t *testing.T) {
 	}
 	if operation.ResponseMode != "json-document" {
 		t.Fatalf("response mode = %q, want %q", operation.ResponseMode, "json-document")
+	}
+}
+
+func TestBuildClients_UsesJsonDocumentForOpaqueObjectErrors(t *testing.T) {
+	const spec = `{
+	  "openapi": "3.0.3",
+	  "info": {
+	    "title": "test",
+	    "version": "1.0.0"
+	  },
+	  "paths": {
+	    "/v0.2/checkouts/{id}/apple-pay-session": {
+	      "put": {
+	        "tags": ["Checkouts"],
+	        "operationId": "CreateApplePaySession",
+	        "parameters": [
+	          {
+	            "name": "id",
+	            "in": "path",
+	            "required": true,
+	            "schema": { "type": "string" }
+	          }
+	        ],
+	        "responses": {
+	          "200": {
+	            "description": "ok",
+	            "content": {
+	              "application/json": {
+	                "schema": { "type": "string" }
+	              }
+	            }
+	          },
+	          "400": {
+	            "description": "bad request",
+	            "content": {
+	              "application/json": {
+	                "schema": { "type": "object" }
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+
+	doc := mustBuildV3Document(t, spec)
+
+	g := New(Config{Namespace: "SumUp"})
+	clients, err := g.buildClients(doc)
+	if err != nil {
+		t.Fatalf("buildClients() error = %v", err)
+	}
+
+	operation := clients[0].Operations[0]
+	if len(operation.ErrorResponses) != 1 {
+		t.Fatalf("error response count = %d, want 1", len(operation.ErrorResponses))
+	}
+	if operation.ErrorResponses[0].ErrorType != "JsonDocument" {
+		t.Fatalf("error type = %q, want %q", operation.ErrorResponses[0].ErrorType, "JsonDocument")
 	}
 }
 


### PR DESCRIPTION
Update the generator to treat opaque JSON consistently by usage: free-form request bodies and model
properties now use JsonObject for ergonomic authoring, while opaque response and error payloads remain
JsonDocument to preserve raw response semantics. This fixes regressions such as Apple Pay session
responses, adds generator coverage for request/response/error behavior, and keeps the generated SDK
surface predictable across untyped JSON schemas.
