### PR TITLE
chore(cd): don't run release please on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,5 +64,6 @@ jobs:
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
+          skip-github-pull-request: "${{ startsWith(github.event.head_commit.message, 'release: ') }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
Prevent release-please from running again when a release PR created by release-please is merged.

The release job now skips release merge commits whose head commit message starts with `release: `.
