### PR TITLE
feat(codegen): generate validated .NET code samples

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,10 @@ jobs:
         with:
           go-version-file: ./codegen/go.mod
 
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
       - name: Generate SDK
         working-directory: codegen
         run: go run ./... --spec ../openapi.json --output ../src/SumUp --namespace SumUp
@@ -34,10 +38,6 @@ jobs:
 
       - name: Check no diff after generation
         run: git diff --exit-code
-
-      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Restore
         run: dotnet restore SumUp.sln

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -6,12 +6,18 @@ on:
       - main
     paths:
       - "codegen/**"
+      - "openapi.json"
+      - "src/SumUp/SumUp.csproj"
+      - "justfile"
       - ".github/workflows/codegen.yaml"
   pull_request:
     branches:
       - main
     paths:
       - "codegen/**"
+      - "openapi.json"
+      - "src/SumUp/SumUp.csproj"
+      - "justfile"
       - ".github/workflows/codegen.yaml"
 
 env:
@@ -50,6 +56,10 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: './codegen/go.mod'
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Test
         run: make test

--- a/.github/workflows/release-code-samples.yaml
+++ b/.github/workflows/release-code-samples.yaml
@@ -1,0 +1,123 @@
+name: Release Code Samples
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: release-code-samples-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync-dotnet-code-samples:
+    name: Sync .NET code samples
+    runs-on: ubuntu-latest
+    env:
+      TARGET_REPOSITORY: sumup/sumup-developer
+      TARGET_BRANCH: automation/dotnet-code-samples
+      TARGET_FILE: src/codesamples/dotnet.json
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/tags/${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: codegen/go.mod
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SUMUP_BOT_APP_ID }}
+          private-key: ${{ secrets.SUMUP_BOT_PRIVATE_KEY }}
+          owner: sumup
+          repositories: sumup-developer
+
+      - name: Checkout target repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ env.TARGET_REPOSITORY }}
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          path: sumup-developer
+          persist-credentials: true
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Prepare target branch
+        working-directory: sumup-developer
+        run: |
+          git fetch origin "${{ env.TARGET_BRANCH }}:refs/remotes/origin/${{ env.TARGET_BRANCH }}" || true
+          git checkout -B "${{ env.TARGET_BRANCH }}" origin/main
+
+      - name: Generate .NET code samples
+        run: |
+          mkdir -p "sumup-developer/$(dirname "${{ env.TARGET_FILE }}")"
+          go -C codegen run . samples \
+            --spec ../openapi.json \
+            --sdk-version-file ../src/SumUp/SumUp.csproj \
+            --output "../sumup-developer/${{ env.TARGET_FILE }}"
+
+      - name: Commit generated samples
+        id: commit
+        working-directory: sumup-developer
+        run: |
+          git add "${{ env.TARGET_FILE }}"
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore: update .NET code samples for ${{ github.event.release.tag_name }}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push branch
+        if: steps.commit.outputs.changed == 'true'
+        working-directory: sumup-developer
+        run: git push --force-with-lease origin "${{ env.TARGET_BRANCH }}"
+
+      - name: Create or update pull request
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          head_ref="sumup:${{ env.TARGET_BRANCH }}"
+          pr_url="$(gh pr list \
+            --repo "${{ env.TARGET_REPOSITORY }}" \
+            --head "$head_ref" \
+            --base main \
+            --state open \
+            --json url \
+            --jq '.[0].url')"
+
+          if [ -n "$pr_url" ]; then
+            gh pr edit "$pr_url" \
+              --repo "${{ env.TARGET_REPOSITORY }}" \
+              --title "chore: update .NET code samples" \
+              --body "Updates \`${{ env.TARGET_FILE }}\` from \`${{ github.repository }}\` release \`${{ github.event.release.tag_name }}\`."
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "${{ env.TARGET_REPOSITORY }}" \
+            --base main \
+            --head "${{ env.TARGET_BRANCH }}" \
+            --title "chore: update .NET code samples" \
+            --body "Updates \`${{ env.TARGET_FILE }}\` from \`${{ github.repository }}\` release \`${{ github.event.release.tag_name }}\`."

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ dist/
 
 # SumUp SDK generated assets
 *.nupkg
+/code-samples.json
 /.turbo/
 .justfile.cache

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -19,3 +19,29 @@ The CLI accepts:
 | `--spec` | Path to the source OpenAPI document (`.json` or `.yaml`). |
 | `--output` | Directory that will host the generated `.cs` files (existing `.g.cs` files inside are overwritten). |
 | `--namespace` | Root C# namespace (defaults to `SumUp`). |
+
+## Generate code samples
+
+Generate the deterministic, versioned catalog of complete C# programs from the repository root:
+
+```sh
+just generate-codesamples
+```
+
+The command writes `code-samples.json` at the repository root. Override the destination when needed:
+
+```sh
+just generate-codesamples /tmp/dotnet.json
+```
+
+The catalog is generated from the same OpenAPI model and SDK method signatures as the client. Every emitted program is compiled against the current SDK by the codegen test suite.
+
+The equivalent direct command is:
+
+```sh
+cd codegen
+go run . samples \
+  --spec ../openapi.json \
+  --sdk-version-file ../src/SumUp/SumUp.csproj \
+  --output ../code-samples.json
+```

--- a/codegen/internal/generator/generator.go
+++ b/codegen/internal/generator/generator.go
@@ -732,6 +732,7 @@ func (g *Generator) buildOperation(path, method, methodName, clientName string, 
 		usesCollections = true
 	}
 	data := operationTemplateData{
+		OperationID:         op.OperationId,
 		MethodName:          methodName,
 		HttpMethod:          method,
 		HttpMethodExpr:      httpMethodExpression(method),
@@ -756,6 +757,7 @@ func (g *Generator) buildOperation(path, method, methodName, clientName string, 
 		HasErrorResponses:   len(errorResponses) > 0,
 		ErrorResponses:      errorResponses,
 		ResponseMode:        responseMode,
+		RequestExamples:     requestExamples(op),
 	}
 	return data, nil
 }
@@ -1608,6 +1610,7 @@ type clientTemplateData struct {
 }
 
 type operationTemplateData struct {
+	OperationID         string
 	MethodName          string
 	HttpMethod          string
 	HttpMethodExpr      string
@@ -1632,6 +1635,7 @@ type operationTemplateData struct {
 	HasErrorResponses   bool
 	ErrorResponses      []errorResponseTemplateData
 	ResponseMode        string
+	RequestExamples     []requestExample
 }
 
 type errorResponseTemplateData struct {

--- a/codegen/internal/generator/samples.go
+++ b/codegen/internal/generator/samples.go
@@ -1,0 +1,425 @@
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"go.yaml.in/yaml/v4"
+)
+
+const sampleCatalogSchemaVersion = 1
+
+// SampleCatalog is the versioned JSON contract consumed by documentation sites.
+type SampleCatalog struct {
+	SchemaVersion  int       `json:"schemaVersion"`
+	Language       string    `json:"language"`
+	SDK            SampleSDK `json:"sdk"`
+	OpenAPIVersion string    `json:"openAPIVersion"`
+	Samples        []Sample  `json:"samples"`
+}
+
+// SampleSDK identifies the package used by every generated sample.
+type SampleSDK struct {
+	Module  string `json:"module"`
+	Version string `json:"version"`
+}
+
+// Sample is a complete C# program for one OpenAPI operation example.
+type Sample struct {
+	ID          string `json:"id"`
+	OperationID string `json:"operationId"`
+	Example     string `json:"example,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	Description string `json:"description,omitempty"`
+	HTTPMethod  string `json:"httpMethod"`
+	Path        string `json:"path"`
+	Source      string `json:"sample"`
+}
+
+type requestExample struct {
+	name        string
+	summary     string
+	description string
+	json        string
+}
+
+// Samples builds a deterministic catalog of compile-ready C# programs.
+func (g *Generator) Samples(doc *v3.Document, sdkVersion string) (*SampleCatalog, error) {
+	if doc == nil || doc.Info == nil {
+		return nil, fmt.Errorf("openapi document info is required")
+	}
+	if strings.TrimSpace(sdkVersion) == "" {
+		return nil, fmt.Errorf("sdk version is required")
+	}
+
+	g.inlineModels = nil
+	g.modelNames = map[string]struct{}{}
+	g.errorModels = map[string]struct{}{}
+	g.optionNames = map[string]struct{}{}
+	if _, err := g.buildModels(doc); err != nil {
+		return nil, fmt.Errorf("build models: %w", err)
+	}
+	clients, err := g.buildClients(doc)
+	if err != nil {
+		return nil, fmt.Errorf("build clients: %w", err)
+	}
+
+	samples := make([]Sample, 0)
+	for _, client := range clients {
+		for _, operation := range client.Operations {
+			if operation.OperationID == "" {
+				return nil, fmt.Errorf("missing operationId for %s %s", strings.ToUpper(operation.HttpMethod), operation.Path)
+			}
+			for _, example := range operation.RequestExamples {
+				id := operation.OperationID
+				if example.name != "" {
+					id += "." + example.name
+				}
+				summary := strings.TrimSpace(operation.Summary)
+				if example.summary != "" {
+					summary = strings.TrimSpace(example.summary)
+				}
+				description := strings.TrimSpace(operation.Description)
+				if example.description != "" {
+					description = strings.TrimSpace(example.description)
+				}
+				samples = append(samples, Sample{
+					ID:          id,
+					OperationID: operation.OperationID,
+					Example:     example.name,
+					Summary:     summary,
+					Description: description,
+					HTTPMethod:  strings.ToUpper(operation.HttpMethod),
+					Path:        operation.Path,
+					Source:      g.renderSample(client, operation, example),
+				})
+			}
+		}
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i].ID < samples[j].ID })
+
+	return &SampleCatalog{
+		SchemaVersion: sampleCatalogSchemaVersion,
+		Language:      "csharp",
+		SDK: SampleSDK{
+			Module:  "SumUp",
+			Version: strings.TrimSpace(sdkVersion),
+		},
+		OpenAPIVersion: strings.TrimSpace(doc.Info.Version),
+		Samples:        samples,
+	}, nil
+}
+
+func (g *Generator) renderSample(client clientTemplateData, operation operationTemplateData, example requestExample) string {
+	arguments := make([]string, 0, len(operation.PathParams)+2)
+	for _, parameter := range operation.PathParams {
+		arguments = append(arguments, g.sampleValue(parameter.TypeName, parameter.Name))
+	}
+	if operation.Body != nil {
+		bodyType := strings.TrimSuffix(operation.Body.TypeName, "?")
+		payload := example.json
+		if payload == "" {
+			payload = "{}"
+		}
+		arguments = append(arguments, fmt.Sprintf(
+			"JsonSerializer.Deserialize<%s>(@\"%s\")!",
+			bodyType,
+			strings.ReplaceAll(payload, "\"", "\"\""),
+		))
+	}
+	if operation.OperationOptions != nil {
+		properties := make([]string, 0, len(operation.OperationOptions.Properties))
+		for _, property := range operation.OperationOptions.Properties {
+			properties = append(properties, fmt.Sprintf(
+				"    %s = %s,",
+				property.PropertyName,
+				g.sampleValue(property.TypeName, property.PropertyName),
+			))
+		}
+		arguments = append(arguments, fmt.Sprintf("new %s\n{\n%s\n}", operation.OperationOptions.Name, strings.Join(properties, "\n")))
+	}
+
+	call := fmt.Sprintf("client.%s.%sAsync()", client.PropertyName, operation.MethodName)
+	if len(arguments) > 0 {
+		indented := make([]string, len(arguments))
+		for i, argument := range arguments {
+			indented[i] = "            " + strings.ReplaceAll(argument, "\n", "\n            ")
+		}
+		call = fmt.Sprintf("client.%s.%sAsync(\n%s)", client.PropertyName, operation.MethodName, strings.Join(indented, ",\n"))
+	}
+
+	return fmt.Sprintf(`using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using SumUp;
+
+public static class Program
+{
+    public static async Task Main()
+    {
+        using var client = new SumUpClient();
+        var response = await %s;
+
+        Console.WriteLine(response.StatusCode);
+    }
+}
+`, call)
+}
+
+func (g *Generator) sampleValue(typeName, name string) string {
+	typeName = strings.TrimSuffix(strings.TrimSpace(typeName), "?")
+	if strings.HasPrefix(typeName, "OptionalQuery<") && strings.HasSuffix(typeName, ">") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(typeName, "OptionalQuery<"), ">")
+		return fmt.Sprintf("%s.From(%s)", typeName, g.sampleValue(inner, name))
+	}
+	if strings.HasPrefix(typeName, "IEnumerable<") && strings.HasSuffix(typeName, ">") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(typeName, "IEnumerable<"), ">")
+		return fmt.Sprintf("Array.Empty<%s>()", inner)
+	}
+	if member, ok := g.firstEnumMember(typeName); ok {
+		return typeName + "." + member
+	}
+
+	switch typeName {
+	case "string":
+		return fmt.Sprintf("%q", sampleString(name))
+	case "bool":
+		return "true"
+	case "byte[]":
+		return "Array.Empty<byte>()"
+	case "int":
+		return "10"
+	case "long":
+		return "10L"
+	case "decimal":
+		return "10.00m"
+	case "float":
+		return "10.0f"
+	case "double":
+		return "10.0d"
+	case "Guid":
+		return `Guid.Parse("00000000-0000-0000-0000-000000000001")`
+	case "DateOnly":
+		return `DateOnly.Parse("2025-01-01")`
+	case "TimeOnly":
+		return `TimeOnly.Parse("12:00:00")`
+	case "DateTimeOffset":
+		return `DateTimeOffset.Parse("2025-01-01T12:00:00Z")`
+	case "JsonDocument":
+		return `JsonDocument.Parse("{}")`
+	case "JsonObject":
+		return `JsonObject.Parse("{}")`
+	default:
+		return fmt.Sprintf("default(%s)", typeName)
+	}
+}
+
+func (g *Generator) firstEnumMember(typeName string) (string, bool) {
+	for _, info := range g.schemaTypes {
+		if info.TypeName != typeName || info.Kind != schemaKindEnum {
+			continue
+		}
+		schema := g.schemaFromProxy(info.Schema)
+		values := g.buildEnumValues(schema)
+		if len(values) > 0 {
+			return values[0].Name, true
+		}
+	}
+	for _, model := range g.inlineModels {
+		if model.Name == typeName && model.Kind == schemaKindEnum && len(model.EnumValues) > 0 {
+			return model.EnumValues[0].Name, true
+		}
+	}
+	return "", false
+}
+
+func sampleString(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.Contains(lower, "merchant") && strings.Contains(lower, "code"):
+		return "your-merchant-code"
+	case strings.Contains(lower, "reader") && strings.Contains(lower, "id"):
+		return "your-reader-id"
+	case strings.Contains(lower, "email"):
+		return "merchant@example.com"
+	case strings.Contains(lower, "url"):
+		return "https://example.com/callback"
+	case strings.Contains(lower, "id"):
+		return "example-id"
+	default:
+		return "example"
+	}
+}
+
+func requestExamples(operation *v3.Operation) []requestExample {
+	if operation == nil || operation.RequestBody == nil || operation.RequestBody.Content == nil {
+		return []requestExample{{}}
+	}
+	mediaType := preferredSampleMediaType(operation.RequestBody.Content)
+	if mediaType == nil {
+		return []requestExample{{}}
+	}
+	fallback := schemaSampleJSON(mediaType.Schema)
+	if mediaType.Examples != nil && mediaType.Examples.Len() > 0 {
+		names := make([]string, 0, mediaType.Examples.Len())
+		for name := range mediaType.Examples.KeysFromOldest() {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		examples := make([]requestExample, 0, len(names))
+		for _, name := range names {
+			example := mediaType.Examples.GetOrZero(name)
+			if example == nil {
+				continue
+			}
+			value := nodeJSON(example.Value)
+			if value == "" {
+				value = fallback
+			}
+			examples = append(examples, requestExample{
+				name:        name,
+				summary:     example.Summary,
+				description: example.Description,
+				json:        value,
+			})
+		}
+		if len(examples) > 0 {
+			return examples
+		}
+	}
+	if value := nodeJSON(mediaType.Example); value != "" {
+		return []requestExample{{json: value}}
+	}
+	return []requestExample{{json: fallback}}
+}
+
+func preferredSampleMediaType(content *orderedmap.Map[string, *v3.MediaType]) *v3.MediaType {
+	if content == nil {
+		return nil
+	}
+	for contentType, mediaType := range content.FromOldest() {
+		lower := strings.ToLower(contentType)
+		if lower == "application/json" || strings.HasSuffix(lower, "+json") {
+			return mediaType
+		}
+	}
+	for _, mediaType := range content.FromOldest() {
+		return mediaType
+	}
+	return nil
+}
+
+func schemaSampleJSON(proxy *base.SchemaProxy) string {
+	value := schemaSampleValue(proxy, 0)
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func schemaSampleValue(proxy *base.SchemaProxy, depth int) any {
+	if proxy == nil || depth > 6 {
+		return map[string]any{}
+	}
+	schema := proxy.Schema()
+	if schema == nil {
+		return map[string]any{}
+	}
+	for _, node := range append(append([]*yaml.Node{}, schema.Examples...), schema.Example, schema.Default, schema.Const) {
+		if value, ok := decodeNode(node); ok {
+			return value
+		}
+	}
+	if len(schema.Enum) > 0 {
+		if value, ok := decodeNode(schema.Enum[0]); ok {
+			return value
+		}
+	}
+	if len(schema.AllOf) > 0 {
+		merged := map[string]any{}
+		for _, part := range schema.AllOf {
+			if value, ok := schemaSampleValue(part, depth+1).(map[string]any); ok {
+				for key, item := range value {
+					merged[key] = item
+				}
+			}
+		}
+		if len(merged) > 0 {
+			return merged
+		}
+	}
+	if len(schema.OneOf) > 0 {
+		return schemaSampleValue(schema.OneOf[0], depth+1)
+	}
+	if len(schema.AnyOf) > 0 {
+		return schemaSampleValue(schema.AnyOf[0], depth+1)
+	}
+	if schemaHasType(schema, "array") && schema.Items != nil && schema.Items.IsA() {
+		return []any{schemaSampleValue(schema.Items.A, depth+1)}
+	}
+	if schemaHasType(schema, "object") || (schema.Properties != nil && schema.Properties.Len() > 0) {
+		value := map[string]any{}
+		required := make(map[string]struct{}, len(schema.Required))
+		for _, name := range schema.Required {
+			required[name] = struct{}{}
+		}
+		if schema.Properties != nil {
+			for name, property := range schema.Properties.FromOldest() {
+				propertySchema := property.Schema()
+				if propertySchema != nil && propertySchema.ReadOnly != nil && *propertySchema.ReadOnly {
+					continue
+				}
+				if _, ok := required[name]; ok || schemaHasExample(propertySchema) {
+					value[name] = schemaSampleValue(property, depth+1)
+				}
+			}
+		}
+		return value
+	}
+	switch {
+	case schemaHasType(schema, "string"):
+		return "example"
+	case schemaHasType(schema, "integer"):
+		return 1
+	case schemaHasType(schema, "number"):
+		return 10.0
+	case schemaHasType(schema, "boolean"):
+		return true
+	default:
+		return map[string]any{}
+	}
+}
+
+func schemaHasExample(schema *base.Schema) bool {
+	return schema != nil && (schema.Example != nil || len(schema.Examples) > 0 || schema.Default != nil || schema.Const != nil || len(schema.Enum) > 0)
+}
+
+func nodeJSON(node *yaml.Node) string {
+	value, ok := decodeNode(node)
+	if !ok {
+		return ""
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func decodeNode(node *yaml.Node) (any, bool) {
+	if node == nil {
+		return nil, false
+	}
+	var value any
+	if err := node.Decode(&value); err != nil {
+		return nil, false
+	}
+	return value, true
+}

--- a/codegen/internal/generator/samples_test.go
+++ b/codegen/internal/generator/samples_test.go
@@ -1,0 +1,148 @@
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/sumup/sumup-dotnet/codegen/internal/spec"
+)
+
+func TestSamples(t *testing.T) {
+	repositoryRoot, catalog := testSampleCatalog(t)
+	if catalog.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", catalog.SchemaVersion)
+	}
+	if catalog.Language != "csharp" {
+		t.Fatalf("Language = %q, want csharp", catalog.Language)
+	}
+	if catalog.SDK.Module != "SumUp" {
+		t.Fatalf("SDK.Module = %q, want SumUp", catalog.SDK.Module)
+	}
+	if catalog.OpenAPIVersion != "1.0.0" {
+		t.Fatalf("OpenAPIVersion = %q, want 1.0.0", catalog.OpenAPIVersion)
+	}
+	if len(catalog.Samples) == 0 {
+		t.Fatal("catalog contains no samples")
+	}
+	if !sort.SliceIsSorted(catalog.Samples, func(i, j int) bool {
+		return catalog.Samples[i].ID < catalog.Samples[j].ID
+	}) {
+		t.Fatal("samples are not sorted by ID")
+	}
+
+	seen := make(map[string]struct{}, len(catalog.Samples))
+	for _, sample := range catalog.Samples {
+		if _, exists := seen[sample.ID]; exists {
+			t.Fatalf("duplicate sample ID %q", sample.ID)
+		}
+		seen[sample.ID] = struct{}{}
+		if !strings.Contains(sample.Source, "public static async Task Main()") {
+			t.Errorf("sample %q is not a complete program", sample.ID)
+		}
+	}
+
+	createCheckout := sampleByID(t, catalog.Samples, "CreateCheckout.HostedCheckout")
+	if !strings.Contains(createCheckout.Source, "client.Checkouts.CreateAsync(") {
+		t.Fatalf("CreateCheckout sample does not call the generated SDK method:\n%s", createCheckout.Source)
+	}
+	if !strings.Contains(createCheckout.Source, `b50pr914-6k0e-3091-a592-890010285b3d`) {
+		t.Fatalf("CreateCheckout sample does not preserve the OpenAPI example:\n%s", createCheckout.Source)
+	}
+	encoded, err := json.Marshal(createCheckout)
+	if err != nil {
+		t.Fatalf("marshal sample: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"sample":`) || strings.Contains(string(encoded), `"source":`) {
+		t.Fatalf("sample JSON does not preserve the portal contract: %s", encoded)
+	}
+
+	compileSamples(t, repositoryRoot, catalog.Samples)
+}
+
+func TestSamplesDeterministic(t *testing.T) {
+	_, first := testSampleCatalog(t)
+	_, second := testSampleCatalog(t)
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal first catalog: %v", err)
+	}
+	secondJSON, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal second catalog: %v", err)
+	}
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatal("sample generation is not deterministic")
+	}
+}
+
+func testSampleCatalog(t *testing.T) (string, *SampleCatalog) {
+	t.Helper()
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	doc, err := spec.Load(t.Context(), filepath.Join(repositoryRoot, "openapi.json"))
+	if err != nil {
+		t.Fatalf("load OpenAPI document: %v", err)
+	}
+	catalog, err := New(Config{Namespace: "SumUp"}).Samples(doc, "test")
+	if err != nil {
+		t.Fatalf("generate samples: %v", err)
+	}
+	return repositoryRoot, catalog
+}
+
+func sampleByID(t *testing.T, samples []Sample, id string) Sample {
+	t.Helper()
+	for _, sample := range samples {
+		if sample.ID == id {
+			return sample
+		}
+	}
+	t.Fatalf("sample %q not found", id)
+	return Sample{}
+}
+
+func compileSamples(t *testing.T, repositoryRoot string, samples []Sample) {
+	t.Helper()
+	if _, err := exec.LookPath("dotnet"); err != nil {
+		t.Fatalf("dotnet is required to compile generated samples: %v", err)
+	}
+	dir := t.TempDir()
+	project := fmt.Sprintf(`<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="%s" />
+  </ItemGroup>
+</Project>
+`, filepath.Join(repositoryRoot, "src", "SumUp", "SumUp.csproj"))
+	if err := os.WriteFile(filepath.Join(dir, "GeneratedSamples.csproj"), []byte(project), 0o600); err != nil {
+		t.Fatalf("write sample project: %v", err)
+	}
+	for i, sample := range samples {
+		className := fmt.Sprintf("Sample%03d", i)
+		source := strings.Replace(sample.Source, "public static class Program", "public static class "+className, 1)
+		if err := os.WriteFile(filepath.Join(dir, className+".cs"), []byte(source), 0o600); err != nil {
+			t.Fatalf("write sample %q: %v", sample.ID, err)
+		}
+	}
+
+	command := exec.CommandContext(t.Context(), "dotnet", "build", "GeneratedSamples.csproj", "--nologo", "--verbosity", "quiet")
+	command.Dir = dir
+	command.Env = append(os.Environ(), "DOTNET_CLI_TELEMETRY_OPTOUT=1", "DOTNET_NOLOGO=1")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compile generated samples: %v\n%s", err, output)
+	}
+}

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -2,61 +2,152 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
+
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 
 	"github.com/sumup/sumup-dotnet/codegen/internal/generator"
 	"github.com/sumup/sumup-dotnet/codegen/internal/spec"
 )
 
+var sdkVersionPattern = regexp.MustCompile(`<Version>\s*([^<]+?)\s*</Version>`)
+
 func main() {
 	log.SetFlags(0)
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}
 
-	var (
-		specPath string
-		output   string
-		ns       string
-	)
-	flag.StringVar(&specPath, "spec", "", "Path to the OpenAPI specification (JSON or YAML).")
-	flag.StringVar(&output, "output", "src/SumUp", "Directory where generated files will be written.")
-	flag.StringVar(&ns, "namespace", "SumUp", "Root namespace for generated code.")
-	flag.Parse()
+func run(args []string, stdout io.Writer) error {
+	if len(args) > 0 && args[0] == "samples" {
+		return runSamples(args[1:], stdout)
+	}
+	return runSDK(args, stdout)
+}
 
+func runSDK(args []string, stdout io.Writer) error {
+	flags := flag.NewFlagSet("codegen", flag.ContinueOnError)
+	flags.SetOutput(stdout)
+	var specPath, output, namespace string
+	flags.StringVar(&specPath, "spec", "", "Path to the OpenAPI specification (JSON or YAML).")
+	flags.StringVar(&output, "output", "src/SumUp", "Directory where generated files will be written.")
+	flags.StringVar(&namespace, "namespace", "SumUp", "Root namespace for generated code.")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
 	if specPath == "" {
-		log.Fatal("spec path is required (pass --spec)")
+		return fmt.Errorf("spec path is required (pass --spec)")
 	}
 
-	absSpec, err := filepath.Abs(specPath)
+	doc, err := loadSpec(specPath)
 	if err != nil {
-		log.Fatalf("resolve spec path: %v", err)
+		return err
 	}
-
-	ctx := context.Background()
-	doc, err := spec.Load(ctx, absSpec)
+	outputDir, err := absolutePath(output)
 	if err != nil {
-		log.Fatalf("load spec: %v", err)
+		return err
 	}
-
-	outputDir := output
-	if !filepath.IsAbs(outputDir) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			log.Fatalf("cwd: %v", err)
-		}
-		outputDir = filepath.Join(cwd, output)
-	}
-
-	gen := generator.New(generator.Config{
-		OutputDir: outputDir,
-		Namespace: ns,
-	})
-
+	gen := generator.New(generator.Config{OutputDir: outputDir, Namespace: namespace})
 	if err := gen.Run(doc); err != nil {
-		log.Fatalf("generate: %v", err)
+		return fmt.Errorf("generate: %w", err)
+	}
+	_, err = fmt.Fprintf(stdout, "Generated SDK files at %s\n", outputDir)
+	return err
+}
+
+func runSamples(args []string, stdout io.Writer) error {
+	flags := flag.NewFlagSet("codegen samples", flag.ContinueOnError)
+	flags.SetOutput(stdout)
+	var specPath, output, sdkVersion, sdkVersionFile, namespace string
+	flags.StringVar(&specPath, "spec", "", "Path to the OpenAPI specification (JSON or YAML).")
+	flags.StringVar(&output, "output", "", "Path to the output JSON file (defaults to stdout).")
+	flags.StringVar(&sdkVersion, "sdk-version", "", "SumUp .NET SDK version represented by the samples.")
+	flags.StringVar(&sdkVersionFile, "sdk-version-file", "", "MSBuild project containing the SDK Version property.")
+	flags.StringVar(&namespace, "namespace", "SumUp", "Root namespace used by generated samples.")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if specPath == "" {
+		return fmt.Errorf("spec path is required (pass --spec)")
+	}
+	if sdkVersion == "" && sdkVersionFile != "" {
+		version, err := readSDKVersion(sdkVersionFile)
+		if err != nil {
+			return err
+		}
+		sdkVersion = version
+	}
+	if sdkVersion == "" {
+		return fmt.Errorf("sdk version is required (pass --sdk-version or --sdk-version-file)")
 	}
 
-	fmt.Printf("Generated SDK files at %s\n", outputDir)
+	doc, err := loadSpec(specPath)
+	if err != nil {
+		return err
+	}
+	gen := generator.New(generator.Config{Namespace: namespace})
+	catalog, err := gen.Samples(doc, sdkVersion)
+	if err != nil {
+		return fmt.Errorf("generate samples: %w", err)
+	}
+	encoded, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode samples: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	if output == "" {
+		_, err = stdout.Write(encoded)
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		return fmt.Errorf("create sample output directory: %w", err)
+	}
+	if err := os.WriteFile(output, encoded, 0o644); err != nil {
+		return fmt.Errorf("write samples: %w", err)
+	}
+	return nil
+}
+
+func loadSpec(path string) (*v3.Document, error) {
+	absSpec, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve spec path: %w", err)
+	}
+	doc, err := spec.Load(context.Background(), absSpec)
+	if err != nil {
+		return nil, fmt.Errorf("load spec: %w", err)
+	}
+	return doc, nil
+}
+
+func absolutePath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cwd: %w", err)
+	}
+	return filepath.Join(cwd, path), nil
+}
+
+func readSDKVersion(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read SDK version file: %w", err)
+	}
+	match := sdkVersionPattern.FindSubmatch(content)
+	if len(match) != 2 {
+		return "", fmt.Errorf("find Version property in %q", path)
+	}
+	return strings.TrimSpace(string(match[1])), nil
 }

--- a/justfile
+++ b/justfile
@@ -11,6 +11,13 @@ help:
 generate:
   go -C codegen run ./... --spec ../openapi.json --output ../src/SumUp --namespace SumUp
 
+# Generate the versioned C# code-sample catalog.
+generate-codesamples output="code-samples.json":
+  go -C codegen run . samples \
+    --spec ../openapi.json \
+    --sdk-version-file ../src/SumUp/SumUp.csproj \
+    --output "{{ absolute_path(output) }}"
+
 # Format the entire solution using dotnet-format.
 fmt:
   dotnet format SumUp.sln


### PR DESCRIPTION
## What

- Add a deterministic, versioned JSON catalog generated from the existing Go codegen model.
- Emit 47 complete C# programs, including nine named OpenAPI request examples.
- Add `just generate-codesamples`, documentation, CI compilation against the local SDK, and release-tag synchronization to `sumup-developer/src/codesamples/dotnet.json`.

## Why

The developer portal needs accurate, SDK-native .NET samples generated from the same OpenAPI model as the client, without publishing a runtime package.

## Validation

- `go test -race -timeout 10m ./...`
- generated-sample compilation against the local SDK
- `golangci-lint run`
- `dotnet format --verify-no-changes`
- `dotnet test` (28 tests)
- SDK regeneration produced no diff
- `actionlint`
- rebased onto the latest `main`
