### PR TITLE
fix(codegen): generate typed request objects in C# samples

### DIFF
--- a/codegen/internal/generator/sample_values.go
+++ b/codegen/internal/generator/sample_values.go
@@ -1,0 +1,159 @@
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Use the same model metadata as SDK generation so property names, inline
+// models, enums, and request-specific types stay aligned with the public API.
+type sampleRenderer struct {
+	models map[string]modelTemplateData
+}
+
+func (r sampleRenderer) value(typeName string, value any) (string, error) {
+	if value == nil {
+		return "null", nil
+	}
+	typeName = strings.TrimSuffix(typeName, "?")
+	if model, ok := r.models[typeName]; ok {
+		if model.Kind == schemaKindEnum {
+			for _, member := range model.EnumValues {
+				if member.Value == fmt.Sprint(value) {
+					return typeName + "." + member.Name, nil
+				}
+			}
+			return "", fmt.Errorf("unknown %s value %v", typeName, value)
+		}
+		if model.IsDictionaryModel {
+			return r.dictionary(typeName, model.DictionaryValueType, value)
+		}
+		object, ok := value.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("expected object for %s, got %T", typeName, value)
+		}
+		var entries []string
+		known := make(map[string]bool, len(model.Properties))
+		for _, property := range model.Properties {
+			known[property.JsonName] = true
+			item, exists := object[property.JsonName]
+			if !exists || property.IsReadOnly {
+				continue
+			}
+			expression, err := r.value(property.TypeName, item)
+			if err != nil {
+				return "", fmt.Errorf("render %s.%s: %w", typeName, property.PropertyName, err)
+			}
+			entries = append(entries, property.PropertyName+" = "+expression)
+		}
+		if model.HasExtensionData {
+			extra := make(map[string]any)
+			for key, item := range object {
+				if !known[key] {
+					extra[key] = item
+				}
+			}
+			if len(extra) > 0 {
+				expression, err := r.dictionary("Dictionary<string, "+model.ExtensionDataValueType+">", model.ExtensionDataValueType, extra)
+				if err != nil {
+					return "", err
+				}
+				entries = append(entries, "AdditionalProperties = "+expression)
+			}
+		}
+		return sampleInitializer(typeName, entries), nil
+	}
+	if strings.HasPrefix(typeName, "IEnumerable<") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(typeName, "IEnumerable<"), ">")
+		items, ok := value.([]any)
+		if !ok {
+			return "", fmt.Errorf("expected array for %s, got %T", typeName, value)
+		}
+		var entries []string
+		for _, item := range items {
+			expression, err := r.value(inner, item)
+			if err != nil {
+				return "", err
+			}
+			entries = append(entries, expression)
+		}
+		return sampleInitializer(inner+"[]", entries), nil
+	}
+	if strings.HasPrefix(typeName, "IDictionary<string, ") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(typeName, "IDictionary<string, "), ">")
+		return r.dictionary("Dictionary<string, "+inner+">", inner, value)
+	}
+	switch typeName {
+	case "JsonObject":
+		return r.dictionary(typeName, "object?", value)
+	case "object":
+		switch value.(type) {
+		case map[string]any:
+			return r.value("JsonObject", value)
+		case []any:
+			return r.value("IEnumerable<object?>", value)
+		case json.Number:
+			return r.value("decimal", value)
+		default:
+			encoded, err := json.Marshal(value)
+			return string(encoded), err
+		}
+	case "JsonDocument", "JsonElement":
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return "", err
+		}
+		expression := "JsonDocument.Parse(" + sampleQuote(string(encoded)) + ")"
+		if typeName == "JsonElement" {
+			expression += ".RootElement.Clone()"
+		}
+		return expression, nil
+	case "string":
+		return sampleQuote(fmt.Sprint(value)), nil
+	case "Guid", "DateOnly", "TimeOnly", "DateTimeOffset":
+		return typeName + ".Parse(" + sampleQuote(fmt.Sprint(value)) + ")", nil
+	case "byte[]":
+		return "Convert.FromBase64String(" + sampleQuote(fmt.Sprint(value)) + ")", nil
+	case "bool", "int", "long", "decimal", "float", "double":
+		suffix := map[string]string{"long": "L", "decimal": "m", "float": "f", "double": "d"}[typeName]
+		return fmt.Sprint(value) + suffix, nil
+	default:
+		return "", fmt.Errorf("unsupported sample type %s", typeName)
+	}
+}
+
+func (r sampleRenderer) dictionary(typeName, valueType string, value any) (string, error) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("expected dictionary for %s, got %T", typeName, value)
+	}
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]string, 0, len(keys))
+	for _, key := range keys {
+		expression, err := r.value(valueType, object[key])
+		if err != nil {
+			return "", fmt.Errorf("render dictionary key %s: %w", key, err)
+		}
+		entries = append(entries, "["+sampleQuote(key)+"] = "+expression)
+	}
+	return sampleInitializer(typeName, entries), nil
+}
+
+func sampleInitializer(typeName string, entries []string) string {
+	if len(entries) == 0 {
+		return "new " + typeName + " { }"
+	}
+	return "new " + typeName + "\n{\n    " + strings.ReplaceAll(strings.Join(entries, ",\n"), "\n", "\n    ") + ",\n}"
+}
+
+func sampleQuote(value string) string {
+	// JSON string escaping is also valid in ordinary C# string literals.
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/codegen/internal/generator/samples.go
+++ b/codegen/internal/generator/samples.go
@@ -61,12 +61,18 @@ func (g *Generator) Samples(doc *v3.Document, sdkVersion string) (*SampleCatalog
 	g.modelNames = map[string]struct{}{}
 	g.errorModels = map[string]struct{}{}
 	g.optionNames = map[string]struct{}{}
-	if _, err := g.buildModels(doc); err != nil {
+	models, err := g.buildModels(doc)
+	if err != nil {
 		return nil, fmt.Errorf("build models: %w", err)
 	}
 	clients, err := g.buildClients(doc)
 	if err != nil {
 		return nil, fmt.Errorf("build clients: %w", err)
+	}
+
+	renderer := sampleRenderer{models: map[string]modelTemplateData{}}
+	for _, model := range append(models, g.inlineModels...) {
+		renderer.models[model.Name] = model
 	}
 
 	samples := make([]Sample, 0)
@@ -88,6 +94,10 @@ func (g *Generator) Samples(doc *v3.Document, sdkVersion string) (*SampleCatalog
 				if example.description != "" {
 					description = strings.TrimSpace(example.description)
 				}
+				source, err := g.renderSample(client, operation, example, renderer)
+				if err != nil {
+					return nil, fmt.Errorf("render sample %s: %w", id, err)
+				}
 				samples = append(samples, Sample{
 					ID:          id,
 					OperationID: operation.OperationID,
@@ -96,7 +106,7 @@ func (g *Generator) Samples(doc *v3.Document, sdkVersion string) (*SampleCatalog
 					Description: description,
 					HTTPMethod:  strings.ToUpper(operation.HttpMethod),
 					Path:        operation.Path,
-					Source:      g.renderSample(client, operation, example),
+					Source:      source,
 				})
 			}
 		}
@@ -115,7 +125,7 @@ func (g *Generator) Samples(doc *v3.Document, sdkVersion string) (*SampleCatalog
 	}, nil
 }
 
-func (g *Generator) renderSample(client clientTemplateData, operation operationTemplateData, example requestExample) string {
+func (g *Generator) renderSample(client clientTemplateData, operation operationTemplateData, example requestExample, renderer sampleRenderer) (string, error) {
 	arguments := make([]string, 0, len(operation.PathParams)+2)
 	for _, parameter := range operation.PathParams {
 		arguments = append(arguments, g.sampleValue(parameter.TypeName, parameter.Name))
@@ -126,11 +136,17 @@ func (g *Generator) renderSample(client clientTemplateData, operation operationT
 		if payload == "" {
 			payload = "{}"
 		}
-		arguments = append(arguments, fmt.Sprintf(
-			"JsonSerializer.Deserialize<%s>(@\"%s\")!",
-			bodyType,
-			strings.ReplaceAll(payload, "\"", "\"\""),
-		))
+		var value any
+		decoder := json.NewDecoder(strings.NewReader(payload))
+		decoder.UseNumber()
+		if err := decoder.Decode(&value); err != nil {
+			return "", fmt.Errorf("decode request example: %w", err)
+		}
+		body, err := renderer.value(bodyType, value)
+		if err != nil {
+			return "", fmt.Errorf("render request body: %w", err)
+		}
+		arguments = append(arguments, body)
 	}
 	if operation.OperationOptions != nil {
 		properties := make([]string, 0, len(operation.OperationOptions.Properties))
@@ -153,7 +169,7 @@ func (g *Generator) renderSample(client clientTemplateData, operation operationT
 		call = fmt.Sprintf("client.%s.%sAsync(\n%s)", client.PropertyName, operation.MethodName, strings.Join(indented, ",\n"))
 	}
 
-	return fmt.Sprintf(`using System;
+	source := fmt.Sprintf(`using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -170,6 +186,10 @@ public static class Program
     }
 }
 `, call)
+	if !strings.Contains(call, "JsonDocument.") && !strings.Contains(call, "JsonElement") {
+		source = strings.Replace(source, "using System.Text.Json;\n", "", 1)
+	}
+	return source, nil
 }
 
 func (g *Generator) sampleValue(typeName, name string) string {

--- a/codegen/internal/generator/samples_test.go
+++ b/codegen/internal/generator/samples_test.go
@@ -45,6 +45,9 @@ func TestSamples(t *testing.T) {
 			t.Fatalf("duplicate sample ID %q", sample.ID)
 		}
 		seen[sample.ID] = struct{}{}
+		if strings.Contains(sample.Source, "JsonSerializer.Deserialize") {
+			t.Errorf("sample %q deserializes its request instead of constructing it", sample.ID)
+		}
 		if !strings.Contains(sample.Source, "public static async Task Main()") {
 			t.Errorf("sample %q is not a complete program", sample.ID)
 		}
@@ -56,6 +59,17 @@ func TestSamples(t *testing.T) {
 	}
 	if !strings.Contains(createCheckout.Source, `b50pr914-6k0e-3091-a592-890010285b3d`) {
 		t.Fatalf("CreateCheckout sample does not preserve the OpenAPI example:\n%s", createCheckout.Source)
+	}
+	reader := sampleByID(t, catalog.Samples, "CreateReader")
+	for _, want := range []string{
+		"new ReadersCreateRequest",
+		"Metadata = new Metadata { }",
+		`Name = "Frontdesk"`,
+		`PairingCode = "4WLFDSBF"`,
+	} {
+		if !strings.Contains(reader.Source, want) {
+			t.Errorf("reader sample missing %q:\n%s", want, reader.Source)
+		}
 	}
 	encoded, err := json.Marshal(createCheckout)
 	if err != nil {
@@ -96,6 +110,65 @@ func TestRequestExamplesPreserveWholeRequestExample(t *testing.T) {
 	examples := requestExamples(operation)
 	if len(examples) != 1 || examples[0].json != `{"selected":"request-example"}` {
 		t.Fatalf("request example was expanded with schema values: %#v", examples)
+	}
+}
+
+func TestSampleRequestValues(t *testing.T) {
+	t.Parallel()
+	renderer := sampleRenderer{models: map[string]modelTemplateData{
+		"Request": {
+			Properties: []modelPropertyTemplateData{
+				{JsonName: "items", PropertyName: "Items", TypeName: "IEnumerable<Item>"},
+				{JsonName: "metadata", PropertyName: "Metadata", TypeName: "IDictionary<string, string>"},
+				{JsonName: "response_only", PropertyName: "ResponseOnly", TypeName: "string", IsReadOnly: true},
+				{JsonName: "omitted", PropertyName: "Omitted", TypeName: "string?"},
+			},
+			HasExtensionData: true, ExtensionDataValueType: "object?",
+		},
+		"Item": {Properties: []modelPropertyTemplateData{
+			{JsonName: "status", PropertyName: "Status", TypeName: "Status?"},
+			{JsonName: "amount", PropertyName: "Amount", TypeName: "decimal"},
+			{JsonName: "note", PropertyName: "Note", TypeName: "string?"},
+		}},
+		"Status": {Kind: schemaKindEnum, EnumValues: []enumValueTemplateData{
+			{Name: "Pending", Value: "pending"}, {Name: "Paid", Value: "paid"},
+		}},
+	}}
+	value := map[string]any{
+		"items":         []any{map[string]any{"status": "paid", "amount": json.Number("123456789.123456789"), "note": nil}},
+		"metadata":      map[string]any{"b": "second", "a": "quote\"\n\x01"},
+		"response_only": "skip", "custom": map[string]any{"enabled": true},
+	}
+	got, err := renderer.value("Request", value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `new Request
+{
+    Items = new Item[]
+    {
+        new Item
+        {
+            Status = Status.Paid,
+            Amount = 123456789.123456789m,
+            Note = null,
+        },
+    },
+    Metadata = new Dictionary<string, string>
+    {
+        ["a"] = "quote\"\n\u0001",
+        ["b"] = "second",
+    },
+    AdditionalProperties = new Dictionary<string, object?>
+    {
+        ["custom"] = new JsonObject
+        {
+            ["enabled"] = true,
+        },
+    },
+}`
+	if got != want {
+		t.Fatalf("request initializer mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 


### PR DESCRIPTION
Replace JSON deserialization with typed initializers so samples show how to use SDK request models directly, including nested objects and collections. For example, emit new `ReadersCreateRequest { Name = "Frontdesk", PairingCode = "4WLFDSBF" }` instead of `JsonSerializer.Deserialize<ReadersCreateRequest>(...)`.